### PR TITLE
High amount of new features and fixes

### DIFF
--- a/ReplayEditor/API.cpp
+++ b/ReplayEditor/API.cpp
@@ -207,6 +207,11 @@ DLLFUN(BOOL) ChangeHashOfBeatmap(const wchar_t *fname)
     filename.push_back('\0');
     std::string hash;
     bool result = osudb::get_hash(filename, hash);
+    if (!result)
+    {
+        osudb::init();
+        result = osudb::get_hash(filename, hash);
+    }
     if (!result) return FALSE;
     replayengine::MutableCurrentView()->mut_metadata().beatmap_hash = hash;
     return TRUE;
@@ -328,11 +333,6 @@ DLLFUN(void) JumpTo(SongTime_t ms)
     audioengine::handle->jump_to(ms);
 }
 
-//DLLFUN(void) RelJump(SongTime_t ms)
-//{
-//    audioengine::handle->rel_jump(ms);
-//}
-
 DLLFUN(void) RelJump(double ms)
 {
     audioengine::handle->rel_jump(ms);
@@ -357,11 +357,6 @@ DLLFUN(float) GetPlaybackSpeed()
 {
     return audioengine::handle->get_playback_speed();
 }
-
-//DLLFUN(SongTime_t) GetTime()
-//{
-//    return audioengine::handle->get_time();
-//}
 
 DLLFUN(double) GetTime()
 {

--- a/ReplayEditor/accuracy_analyzer.cpp
+++ b/ReplayEditor/accuracy_analyzer.cpp
@@ -58,25 +58,64 @@ void accuracy_analyzer::analyze(Stats* stats, bool do_trace)
     for (size_t i = 0; i < beatmapengine::hitobjects.size(); ++i) {
         beatmapengine::hitobjects[i].is_miss = true;
     }
+
+    bool is_holding;
+    const slider_t* curr_slider = nullptr;
+    SongTime_t curr_slider_start = 0;
+
     while (replayframe_index < replayengine::CurrentView()->frames().size() &&
            hitobject_index < beatmapengine::hitobjects.size()) {
         const auto& curr_frame = replayengine::CurrentView()->frames()[replayframe_index];
         const auto& prev_frame = replayengine::CurrentView()->frames()[replayframe_index - 1];
-        const bool is_press = IS_PRESSED(prev_frame.pressed_mouse1(), prev_frame.pressed_mouse2(),
+        const int is_press = IS_PRESSED_INT(prev_frame.pressed_mouse1(), prev_frame.pressed_mouse2(),
                                          curr_frame.pressed_mouse1(), curr_frame.pressed_mouse2());
         auto& curr_obj = beatmapengine::hitobjects[hitobject_index];
-        if (curr_obj.hitobject_type == HitObjectType::SliderTick) {
+        if (curr_obj.hitobject_type == HitObjectType::Slider) {
+            is_holding = true;
+            curr_slider = curr_obj.slider;
+            curr_slider_start = curr_obj.start;
+        }
+
+        if (curr_obj.hitobject_type == HitObjectType::SliderTick ||
+            curr_obj.hitobject_type == HitObjectType::SliderEnd) {
+            
+            //const float ball_radius = beatmapengine::circleradius() * (is_holding ? 2.4f : 1.0f);
+            // This is not working even though the algo seems correct
+            const float ball_radius = beatmapengine::circleradius() * 2.4f;
+
+            glm::vec2 sliderball_pos;
+            bool inside_slider_ball;
+
+            const bool prev_frame_pressed = prev_frame.pressed_mouse1() || prev_frame.pressed_mouse2();
+            const bool curr_frame_pressed = curr_frame.pressed_mouse1() || curr_frame.pressed_mouse2();
+
+            // check is inside slidercircle
+
+            if (curr_slider_start > curr_frame.ms)
+            {
+                ++replayframe_index;
+                continue;
+            }
+
+            curr_slider->position_at_time(curr_frame.ms, sliderball_pos);
+
+            if (beatmapengine::hitobjects_inverted) sliderball_pos.y = 384.f - sliderball_pos.y;
+            inside_slider_ball = glm::distance(sliderball_pos, curr_frame.p) <= ball_radius;
+
+            is_holding = prev_frame_pressed && curr_frame_pressed && inside_slider_ball;
+
             if (curr_frame.ms < curr_obj.start) {
                 // if we are not yet at the tick interval then wait until we are
                 ++replayframe_index;
                 continue;
             }
-            const bool prev_frame_pressed = prev_frame.pressed_mouse1() || prev_frame.pressed_mouse2();
-            const bool curr_frame_pressed = curr_frame.pressed_mouse1() || curr_frame.pressed_mouse2();
-            const float ball_radius = beatmapengine::circleradius() * 2.4f;
+
+            double interpolation = double(curr_obj.start - prev_frame.ms) / (curr_frame.ms - prev_frame.ms);
+            glm::vec2 frame_pos = glm::mix(prev_frame.p, curr_frame.p, interpolation);
             glm::vec2 hitobj_pos = curr_obj.pos;
             if (beatmapengine::hitobjects_inverted) hitobj_pos.y = 384.f - hitobj_pos.y;
-            const bool inside_slider_ball = glm::distance(hitobj_pos, curr_frame.p) <= ball_radius;
+
+            inside_slider_ball = glm::distance(hitobj_pos, frame_pos) <= ball_radius;
             if (do_trace)
                 log << "SldTk: Object #" << hitobject_index << "; Frame #" << replayframe_index << "; "
                     << prev_frame_pressed << curr_frame_pressed << inside_slider_ball << std::endl;
@@ -84,6 +123,10 @@ void accuracy_analyzer::analyze(Stats* stats, bool do_trace)
                 // all conditions met for good slider tick
                 curr_obj.is_miss = false;
                 curr_obj.hit_error = 0;
+            }
+            else
+            {
+                curr_obj.is_miss = true;
             }
             ++hitobject_index;
         } else if (is_press) {
@@ -121,7 +164,7 @@ void accuracy_analyzer::analyze(Stats* stats, bool do_trace)
                 continue;
             }
             // we have a hit
-            const int error = curr_frame.ms - curr_obj.start;
+            int error = curr_frame.ms - curr_obj.start;
             if (std::abs(error) <= window50) {
                 if (do_trace)
                     log << "Press: Object #" << hitobject_index << "; Frame #" << replayframe_index << "; Hit ("
@@ -130,6 +173,41 @@ void accuracy_analyzer::analyze(Stats* stats, bool do_trace)
                 curr_obj.hit_error = error;
             }
             ++hitobject_index;
+
+            //if doubletapped
+            if (is_press == 2)
+            {
+                if (hitobject_index == beatmapengine::hitobjects.size()) continue;
+
+                auto& next_obj = beatmapengine::hitobjects[hitobject_index];
+
+                if (curr_frame.ms < next_obj.animation_start()) {
+                    // if it is not on screen then ignore this hit
+                    ++replayframe_index;
+                    continue;
+                }
+
+                glm::vec2 hitobj_pos = next_obj.pos;
+                if (beatmapengine::hitobjects_inverted) hitobj_pos.y = 384.f - hitobj_pos.y;
+                if (glm::distance(hitobj_pos, curr_frame.p) > radius) {
+                    if (do_trace)
+                        log << "Press: Object #" << hitobject_index << "; Frame #" << replayframe_index
+                            << "; Ignore - missed hitcircle" << std::endl;
+                    // if this hit misses the circle then ignore it
+                    ++replayframe_index;
+                    continue;
+                }
+
+                error = curr_frame.ms - next_obj.start;
+                if (std::abs(error) <= window50) {
+                    if (do_trace)
+                        log << "Press: Object #" << hitobject_index << "; Frame #" << replayframe_index << "; Hit ("
+                            << error << " ms)" << std::endl;
+                    next_obj.is_miss = false;
+                    next_obj.hit_error = error;
+                }
+                ++hitobject_index;
+            }
         }
         ++replayframe_index;
     }
@@ -176,7 +254,7 @@ int accuracy_analyzer::next_hitobject(std::function<bool(const hitobject_t&)> fu
 {
     auto iter = std::lower_bound(beatmapengine::hitobjects.begin(), beatmapengine::hitobjects.end(),
                                  audioengine::handle->get_time(),
-                                 [](const hitobject_t& lhs, SongTime_t rhs) { return lhs.start < rhs; });
+                                 [](const hitobject_t& lhs, double rhs) { return lhs.start < rhs; });
     for (; iter != beatmapengine::hitobjects.end(); ++iter) {
         if (func(*iter)) {
             audioengine::handle->jump_to(iter->start + 1);

--- a/ReplayEditor/audioengine.cpp
+++ b/ReplayEditor/audioengine.cpp
@@ -30,15 +30,12 @@ class BassAudioEngine : public AudioEngine
     bool is_playing() override;
     bool is_paused() override;
     bool is_stopped() override;
-    /*void jump_to(SongTime_t ms) override;
-    void rel_jump(SongTime_t ms) override;*/
     void jump_to(double ms) override;
     void rel_jump(double ms) override;
     void set_volume(float) override;
     float get_volume() override;
     void set_playback_speed(float) override;
     float get_playback_speed() override;
-    //SongTime_t get_time() override;
     double get_time() override;
 
    private:
@@ -62,15 +59,12 @@ class FakeAudioEngine : public AudioEngine
     bool is_playing() override;
     bool is_paused() override;
     bool is_stopped() override;
-    /*void jump_to(SongTime_t ms) override;
-    void rel_jump(SongTime_t ms) override;*/
     void jump_to(double ms) override;
     void rel_jump(double ms) override;
     void set_volume(float) override;
     float get_volume() override;
     void set_playback_speed(float) override;
     float get_playback_speed() override;
-    // SongTime_t get_time() override;
     double get_time() override;
 
    private:
@@ -195,20 +189,6 @@ bool BassAudioEngine::is_stopped()
     return status == StreamStatus::Stopped;
 }
 
-//void BassAudioEngine::jump_to(SongTime_t ms)
-//{
-//    if (stream) {
-//        if (ms < 0) ms = 0;
-//        const QWORD byte_pos = BASS_ChannelSeconds2Bytes(stream, static_cast<double>(ms / 1000.0));
-//        BASS_ChannelSetPosition(stream, byte_pos, BASS_POS_BYTE);
-//    }
-//}
-//
-//void BassAudioEngine::rel_jump(SongTime_t ms)
-//{
-//    jump_to(get_time() + ms);
-//}
-
 void BassAudioEngine::jump_to(double ms)
 {
     if (stream) {
@@ -250,17 +230,6 @@ float BassAudioEngine::get_playback_speed()
 {
     return speed;
 }
-
-//SongTime_t BassAudioEngine::get_time()
-//{
-//    if (stream) {
-//        const QWORD byte_pos = BASS_ChannelGetPosition(stream, BASS_POS_BYTE);
-//        const double ms = BASS_ChannelBytes2Seconds(stream, byte_pos);
-//        return static_cast<SongTime_t>(ms * 1000. + 0.5);
-//    } else {
-//        return 0;
-//    }
-//}
 
 double BassAudioEngine::get_time()
 {
@@ -312,22 +281,6 @@ bool FakeAudioEngine::is_stopped()
     return m_status == StreamStatus::Stopped;
 }
 
-//void FakeAudioEngine::jump_to(SongTime_t ms)
-//{
-//    if (ms < m_start_time) {
-//        m_current_time = m_start_time;
-//    } else if (ms > m_end_time) {
-//        m_current_time = m_end_time;
-//    } else {
-//        m_current_time = ms;
-//    }
-//}
-//
-//void FakeAudioEngine::rel_jump(SongTime_t ms)
-//{
-//    jump_to(get_time() + ms);
-//}
-
 void FakeAudioEngine::jump_to(double ms)
 {
     if (ms < m_start_time) {
@@ -363,11 +316,6 @@ float FakeAudioEngine::get_playback_speed()
 {
     return m_speed;
 }
-
-//SongTime_t FakeAudioEngine::get_time()
-//{
-//    return m_current_time;
-//}
 
 double FakeAudioEngine::get_time()
 {

--- a/ReplayEditor/audioengine.cpp
+++ b/ReplayEditor/audioengine.cpp
@@ -267,7 +267,7 @@ double BassAudioEngine::get_time()
     if (stream) {
         const QWORD byte_pos = BASS_ChannelGetPosition(stream, BASS_POS_BYTE);
         const double ms = BASS_ChannelBytes2Seconds(stream, byte_pos);
-        return ms * 1000. + 0.5;
+        return ms * 1000.0;
     } else {
         return 0;
     }

--- a/ReplayEditor/audioengine.cpp
+++ b/ReplayEditor/audioengine.cpp
@@ -30,13 +30,16 @@ class BassAudioEngine : public AudioEngine
     bool is_playing() override;
     bool is_paused() override;
     bool is_stopped() override;
-    void jump_to(SongTime_t ms) override;
-    void rel_jump(SongTime_t ms) override;
+    /*void jump_to(SongTime_t ms) override;
+    void rel_jump(SongTime_t ms) override;*/
+    void jump_to(double ms) override;
+    void rel_jump(double ms) override;
     void set_volume(float) override;
     float get_volume() override;
     void set_playback_speed(float) override;
     float get_playback_speed() override;
-    SongTime_t get_time() override;
+    //SongTime_t get_time() override;
+    double get_time() override;
 
    private:
     HSTREAM stream = 0;
@@ -59,13 +62,16 @@ class FakeAudioEngine : public AudioEngine
     bool is_playing() override;
     bool is_paused() override;
     bool is_stopped() override;
-    void jump_to(SongTime_t ms) override;
-    void rel_jump(SongTime_t ms) override;
+    /*void jump_to(SongTime_t ms) override;
+    void rel_jump(SongTime_t ms) override;*/
+    void jump_to(double ms) override;
+    void rel_jump(double ms) override;
     void set_volume(float) override;
     float get_volume() override;
     void set_playback_speed(float) override;
     float get_playback_speed() override;
-    SongTime_t get_time() override;
+    // SongTime_t get_time() override;
+    double get_time() override;
 
    private:
     SongTime_t m_current_time = 0;
@@ -189,19 +195,34 @@ bool BassAudioEngine::is_stopped()
     return status == StreamStatus::Stopped;
 }
 
-void BassAudioEngine::jump_to(SongTime_t ms)
+//void BassAudioEngine::jump_to(SongTime_t ms)
+//{
+//    if (stream) {
+//        if (ms < 0) ms = 0;
+//        const QWORD byte_pos = BASS_ChannelSeconds2Bytes(stream, static_cast<double>(ms / 1000.0));
+//        BASS_ChannelSetPosition(stream, byte_pos, BASS_POS_BYTE);
+//    }
+//}
+//
+//void BassAudioEngine::rel_jump(SongTime_t ms)
+//{
+//    jump_to(get_time() + ms);
+//}
+
+void BassAudioEngine::jump_to(double ms)
 {
     if (stream) {
         if (ms < 0) ms = 0;
-        const QWORD byte_pos = BASS_ChannelSeconds2Bytes(stream, static_cast<double>(ms / 1000.0));
+        const QWORD byte_pos = BASS_ChannelSeconds2Bytes(stream, ms / 1000.0);
         BASS_ChannelSetPosition(stream, byte_pos, BASS_POS_BYTE);
     }
 }
 
-void BassAudioEngine::rel_jump(SongTime_t ms)
+void BassAudioEngine::rel_jump(double ms)
 {
     jump_to(get_time() + ms);
 }
+
 
 void BassAudioEngine::set_volume(float value)
 {
@@ -230,12 +251,23 @@ float BassAudioEngine::get_playback_speed()
     return speed;
 }
 
-SongTime_t BassAudioEngine::get_time()
+//SongTime_t BassAudioEngine::get_time()
+//{
+//    if (stream) {
+//        const QWORD byte_pos = BASS_ChannelGetPosition(stream, BASS_POS_BYTE);
+//        const double ms = BASS_ChannelBytes2Seconds(stream, byte_pos);
+//        return static_cast<SongTime_t>(ms * 1000. + 0.5);
+//    } else {
+//        return 0;
+//    }
+//}
+
+double BassAudioEngine::get_time()
 {
     if (stream) {
         const QWORD byte_pos = BASS_ChannelGetPosition(stream, BASS_POS_BYTE);
         const double ms = BASS_ChannelBytes2Seconds(stream, byte_pos);
-        return static_cast<SongTime_t>(ms * 1000. + 0.5);
+        return ms * 1000. + 0.5;
     } else {
         return 0;
     }
@@ -280,7 +312,23 @@ bool FakeAudioEngine::is_stopped()
     return m_status == StreamStatus::Stopped;
 }
 
-void FakeAudioEngine::jump_to(SongTime_t ms)
+//void FakeAudioEngine::jump_to(SongTime_t ms)
+//{
+//    if (ms < m_start_time) {
+//        m_current_time = m_start_time;
+//    } else if (ms > m_end_time) {
+//        m_current_time = m_end_time;
+//    } else {
+//        m_current_time = ms;
+//    }
+//}
+//
+//void FakeAudioEngine::rel_jump(SongTime_t ms)
+//{
+//    jump_to(get_time() + ms);
+//}
+
+void FakeAudioEngine::jump_to(double ms)
 {
     if (ms < m_start_time) {
         m_current_time = m_start_time;
@@ -291,7 +339,7 @@ void FakeAudioEngine::jump_to(SongTime_t ms)
     }
 }
 
-void FakeAudioEngine::rel_jump(SongTime_t ms)
+void FakeAudioEngine::rel_jump(double ms)
 {
     jump_to(get_time() + ms);
 }
@@ -316,7 +364,12 @@ float FakeAudioEngine::get_playback_speed()
     return m_speed;
 }
 
-SongTime_t FakeAudioEngine::get_time()
+//SongTime_t FakeAudioEngine::get_time()
+//{
+//    return m_current_time;
+//}
+
+double FakeAudioEngine::get_time()
 {
     return m_current_time;
 }

--- a/ReplayEditor/audioengine.hpp
+++ b/ReplayEditor/audioengine.hpp
@@ -16,13 +16,16 @@ class AudioEngine
     virtual bool is_playing() = 0;
     virtual bool is_paused() = 0;
     virtual bool is_stopped() = 0;
-    virtual void jump_to(SongTime_t ms) = 0;
-    virtual void rel_jump(SongTime_t ms) = 0;
+    /*virtual void jump_to(SongTime_t ms) = 0;
+    virtual void rel_jump(SongTime_t ms) = 0;*/
+    virtual void jump_to(double ms) = 0;
+    virtual void rel_jump(double ms) = 0;
     virtual void set_volume(float) = 0;
     virtual float get_volume() = 0;
     virtual void set_playback_speed(float) = 0;
     virtual float get_playback_speed() = 0;
-    virtual SongTime_t get_time() = 0;
+    //virtual SongTime_t get_time() = 0;
+    virtual double get_time() = 0;
 };
 
 bool init();

--- a/ReplayEditor/beatmapengine.cpp
+++ b/ReplayEditor/beatmapengine.cpp
@@ -490,7 +490,6 @@ void beatmapengine::draw_windows(SongTime_t ms)
     if (start == hitobjects.end()) return;
     if (end != hitobjects.end()) ++end;
 
-    // glMatrixMode(GL_PROJECTION);
     glPushMatrix();
     glLoadIdentity();
     glDisable(GL_TEXTURE_2D);

--- a/ReplayEditor/beatmapengine.cpp
+++ b/ReplayEditor/beatmapengine.cpp
@@ -13,6 +13,7 @@
 #include "hitobject.hpp"
 #include "replayengine.hpp"
 
+std::wstring beatmapengine::path;
 float beatmapengine::stack_leniency;
 float beatmapengine::hp;
 float beatmapengine::cs;
@@ -202,6 +203,7 @@ static void add_slider_ticks()
     using namespace beatmapengine;
     const size_t num_objects = hitobjects.size();
     constexpr size_t arbitrary_slider_tick_limit = 10000;
+    constexpr SongTime_t legacy_last_tick_offset = 36;
     for (size_t i = 0; i < num_objects; ++i) {
         if (!hitobjects[i].slider) continue;
         constexpr float slider_leniency = 10.f;
@@ -223,9 +225,12 @@ static void add_slider_ticks()
             }
             t += dt;
         }
+
+        const SongTime_t dur = static_cast<SongTime_t>(hitobjects[i].slider->duration());
+        SongTime_t this_tick_delay = 0;
+
         for (int k = 1; k < hitobjects[i].slider->repeat; ++k) {
-            const SongTime_t dur = static_cast<SongTime_t>(hitobjects[i].slider->duration());
-            const SongTime_t this_tick_delay = k * dur;
+            this_tick_delay = k * dur;
             const SongTime_t reverse_tick_aug = (k + 1) * dur + 2 * hitobjects[i].start;
             for (auto index : just_added) {
                 hitobjects.emplace_back(hitobjects[index]);
@@ -240,6 +245,21 @@ static void add_slider_ticks()
                     hitobjects.back().start = hitobjects.back().end;
                 }
             }
+        }
+        // sliderend
+        if ((hitobjects[i].slider->repeat % 2) == 0) {
+            this_tick_delay = this_tick_delay + 0; 
+        }
+        const SongTime_t slider_end_offset = std::max(dur / 2, dur - legacy_last_tick_offset);
+        const SongTime_t slider_end_adjusted_offset =
+            (hitobjects[i].slider->repeat % 2) == 0 ? dur - slider_end_offset : slider_end_offset;
+
+        hitobjects[i].slider->position_at_time(hitobjects[i].start + slider_end_adjusted_offset, hitobjects[i].start,
+                                               hitobjects[i].end, pos);
+        hitobjects.emplace_back(pos, hitobjects[i].start + this_tick_delay + slider_end_offset, hitobjects[i].end,
+                                HitObjectType::SliderEnd);
+        if (hitobjects.back().start > hitobjects.back().end) {
+            hitobjects.back().start = hitobjects.back().end;
         }
     }
 }
@@ -446,15 +466,50 @@ bool beatmapengine::init(const std::wstring &fname)
     return true;
 }
 
-void beatmapengine::draw(SongTime_t ms)
+void beatmapengine::draw(SongTime_t ms, bool draw_sliderend_range)
 {
     static std::vector<const hitobject_t *> objs_to_draw;
     objs_to_draw.clear();
     interval_tree_search(root_hitobject, ms, objs_to_draw);
     for (int i = static_cast<int>(objs_to_draw.size()) - 1; i >= 0; --i) {
-        objs_to_draw[i]->draw_bg(ms);
+        objs_to_draw[i]->draw_bg(ms, draw_sliderend_range);
     }
     for (int i = static_cast<int>(objs_to_draw.size()) - 1; i >= 0; --i) {
         objs_to_draw[i]->draw_fg(ms);
     }
+}
+
+const SongTime_t trail_length = 1000;
+
+void beatmapengine::draw_windows(SongTime_t ms)
+{
+    auto start = std::lower_bound(hitobjects.begin(), hitobjects.end(), ms - trail_length,
+                                  [](const hitobject_t &lhs, SongTime_t rhs) { return lhs.start < rhs; });
+    auto end = std::lower_bound(hitobjects.begin(), hitobjects.end(), ms,
+                                [](const hitobject_t &lhs, SongTime_t rhs) { return lhs.start < rhs; });
+    if (start == hitobjects.end()) return;
+    if (end != hitobjects.end()) ++end;
+
+    // glMatrixMode(GL_PROJECTION);
+    glPushMatrix();
+    glLoadIdentity();
+    glDisable(GL_TEXTURE_2D);
+
+    glColor4f(1, 0.5, 0, 1);
+    for (auto i = start; i != end; ++i) {
+        i->draw_window(ms, hitwindow50());
+    }
+
+    glColor4f(0, 1, 0, 1);
+    for (auto i = start; i != end; ++i) {
+        i->draw_window(ms, hitwindow100());
+    }
+
+    glColor4f(0, 0, 1, 1);  
+    for (auto i = start; i != end; ++i) {
+        i->draw_window(ms, hitwindow300());
+    }
+
+    glEnable(GL_TEXTURE_2D);
+    glPopMatrix();
 }

--- a/ReplayEditor/beatmapengine.hpp
+++ b/ReplayEditor/beatmapengine.hpp
@@ -11,7 +11,9 @@ namespace beatmapengine
 bool init(const std::wstring &f);
 float slider_velocity_at(SongTime_t);
 float beat_length_at(SongTime_t);
-void draw(SongTime_t);
+void draw(SongTime_t, bool);
+void draw_windows(SongTime_t);
+extern std::wstring path;
 extern std::vector<hitobject_t> hitobjects;
 extern float stack_leniency;
 extern float hp;

--- a/ReplayEditor/hitobject.cpp
+++ b/ReplayEditor/hitobject.cpp
@@ -8,12 +8,15 @@
 #include "beatmapengine.hpp"
 #include "replayengine.hpp"
 #include "texture.hpp"
+#include "ui.hpp"
 
 #define MIN_SONG_TIME INT32_MIN
 
 #define KIND_IS_CIRCLE (kind & 1)
 #define KIND_IS_SLIDER (kind & 2)
 #define KIND_IS_SPINNER (kind & 8)
+
+#define RATIO(a, b) (static_cast<float>(a) / static_cast<float>(b))
 
 static float approach(const SongTime_t start, const SongTime_t ms)
 {
@@ -99,7 +102,7 @@ hitobject_t::hitobject_t(const glm::vec2 &my_pos, SongTime_t my_start, SongTime_
 {
 }
 
-void hitobject_t::draw_bg(SongTime_t ms) const
+void hitobject_t::draw_bg(SongTime_t ms, bool draw_sliderend_range) const
 {
     switch (hitobject_type) {
         case HitObjectType::Circle:
@@ -107,12 +110,12 @@ void hitobject_t::draw_bg(SongTime_t ms) const
             const float o = opacity(start, end, ms);
             glm::vec2 size = glm::vec2(beatmapengine::circleradius() * 2.0f);
             if (slider) {
-                slider->draw(ms, start, end, o);
+                slider->draw(ms, start, end, o, draw_sliderend_range);
                 glColor4f(1.0f, 1.0f, 1.0f, o);
-                if (beatmapengine::hitobjects_inverted)
+                /*if (beatmapengine::hitobjects_inverted)
                     textures::hitcircle->draw(invert_vec(slider->end_pos()), size * 0.5f, size);
                 else
-                    textures::hitcircle->draw(slider->end_pos(), size * 0.5f, size);
+                    textures::hitcircle->draw(slider->end_pos(), size * 0.5f, size);*/
             }
             glColor4f(1.0f, 1.0f, 1.0f, o);
             if (beatmapengine::hitobjects_inverted)
@@ -159,7 +162,48 @@ void hitobject_t::draw_fg(SongTime_t ms) const
                 textures::slidertick->draw(pos, size * 0.5f, size);
             break;
         }
+        case HitObjectType::SliderEnd: {
+            glm::vec2 size = glm::vec2(beatmapengine::circleradius() * 2.0f);
+            glColor4f(0.0f, 1.0f, 1.0f, o);
+            if (beatmapengine::hitobjects_inverted)
+                textures::slideredge->draw(invert_vec(pos), size * 0.5f, size);
+            else
+                textures::slideredge->draw(pos, size * 0.5f, size);
+            break;
+        }
     }
+    glBegin(GL_LINES);
+    glVertex2f(0, 0);
+    glVertex2f(1, 1);
+    glEnd();
+}
+
+void _draw_window(SongTime_t object_time, SongTime_t current_time, SongTime_t window)
+{
+    constexpr float bar_top_y = -0.95f;
+    constexpr float bar_height = 0.05f;
+
+    glBegin(GL_QUADS);
+    const float xpos1 = 2.f * RATIO(object_time - current_time - window, ui::trail_length) + 1.f;
+    const float xpos2 = 2.f * RATIO(object_time - current_time + window, ui::trail_length) + 1.f;
+    glVertex2f(xpos1, bar_top_y - bar_height / 8);
+    glVertex2f(xpos1, bar_top_y + bar_height / 8);
+    glVertex2f(xpos2, bar_top_y + bar_height / 8);
+    glVertex2f(xpos2, bar_top_y - bar_height / 8);
+    glEnd();
+}
+
+void hitobject_t::draw_window(SongTime_t ms, SongTime_t window) const
+{
+    
+
+    switch (hitobject_type) {
+        case HitObjectType::Circle:
+        case HitObjectType::Slider:
+            _draw_window(this->start, ms, window);
+    }
+    
+    
 }
 
 void hitobject_t::destroy()

--- a/ReplayEditor/hitobject.cpp
+++ b/ReplayEditor/hitobject.cpp
@@ -16,8 +16,6 @@
 #define KIND_IS_SLIDER (kind & 2)
 #define KIND_IS_SPINNER (kind & 8)
 
-#define RATIO(a, b) (static_cast<float>(a) / static_cast<float>(b))
-
 static float approach(const SongTime_t start, const SongTime_t ms)
 {
     const SongTime_t pre = beatmapengine::preempt();

--- a/ReplayEditor/hitobject.hpp
+++ b/ReplayEditor/hitobject.hpp
@@ -66,8 +66,9 @@ class hitobject_t
     hitobject_t(const glm::vec2& my_pos, SongTime_t my_start, SongTime_t my_end,
                 HitObjectType my_hit_object_type) noexcept;
     void destroy();
-    void draw_bg(SongTime_t) const;
+    void draw_bg(SongTime_t, bool) const;
     void draw_fg(SongTime_t) const;
+    void draw_window(SongTime_t, SongTime_t) const;
     bool operator<(const hitobject_t& rhs) const
     {
         return animation_start() < rhs.animation_start();

--- a/ReplayEditor/osudb.cpp
+++ b/ReplayEditor/osudb.cpp
@@ -32,6 +32,8 @@ bool init()
         fatal("osu!.db not found");
         return false;
     }
+    beatmaps.clear();
+    beatmaps_reverse.clear();
     int32_t version;
     r >> version;
     // folder count (4)

--- a/ReplayEditor/osudb.cpp
+++ b/ReplayEditor/osudb.cpp
@@ -21,6 +21,7 @@ struct osudb_entry_t {
 };
 
 std::map<std::string, osudb_entry_t> beatmaps;
+std::map<std::wstring, std::string> beatmaps_reverse;
 
 }  // namespace
 
@@ -121,6 +122,7 @@ bool init()
         entry.osu_path = string_to_wstring(folder_name + '/' + partial_osu_path);
         entry.song_path = string_to_wstring(folder_name + '/' + partial_song_path);
         beatmaps.insert({hash, entry});
+        beatmaps_reverse.insert({entry.osu_path, hash});
     }
     return true;
 }
@@ -131,6 +133,14 @@ bool get_entry(const std::string &hash, std::wstring &osu_path, std::wstring &so
     if (entry == beatmaps.end()) return false;
     osu_path = entry->second.osu_path;
     song_path = entry->second.song_path;
+    return true;
+}
+
+bool get_hash(const std::wstring &osu_path, std::string &hash)
+{
+    auto entry = beatmaps_reverse.find(osu_path);
+    if (entry == beatmaps_reverse.end()) return false;
+    hash = entry->second;
     return true;
 }
 

--- a/ReplayEditor/osudb.hpp
+++ b/ReplayEditor/osudb.hpp
@@ -15,5 +15,6 @@ namespace osudb
 
 bool init();
 bool get_entry(const std::string &hash, std::wstring &osu_path, std::wstring &song_path);
+bool get_hash(const std::wstring &osu_path, std::string &hash);
 
 }  // namespace osudb

--- a/ReplayEditor/replayengine.cpp
+++ b/ReplayEditor/replayengine.cpp
@@ -579,7 +579,7 @@ bool Replay::center_frames_range()
         if (difference < size) return 0;
 
         int i = 1;
-        double base = (double)difference / (size + 1);
+        double base = static_cast<double>(difference) / (size + 1);
 
         for (auto frame = m_frames.begin() + m_mark_in + 1; frame != m_frames.begin() + m_mark_out + 1; ++frame) {
             frame->ms = m_frames[m_mark_in].ms + base * i;
@@ -591,7 +591,7 @@ bool Replay::center_frames_range()
         if (difference < size) return 0;
 
         int i = 1;
-        double base = (double)difference / (size + 1);
+        double base = static_cast<double>(difference) / (size + 1);
 
         for (auto frame = m_frames.begin() + m_mark_in; frame != m_frames.begin() + m_mark_out; ++frame) {
             frame->ms = m_frames[m_mark_in - 1].ms + base * i;
@@ -604,7 +604,7 @@ bool Replay::center_frames_range()
         if (difference < size) return 0;
 
         int i = 1;
-        double base = (double)difference / (size + 1);
+        double base = static_cast<double>(difference) / (size + 1);
 
         for (auto frame = m_frames.begin() + m_mark_in; frame != m_frames.begin() + m_mark_out + 1; ++frame) {
             frame->ms = m_frames[m_mark_in - 1].ms + base * i;
@@ -620,13 +620,13 @@ bool Replay::scale_frames(float scale)
     if (m_mark_out != m_frames.size() - 1) {
         SongTime_t initial_delta = m_frames[m_mark_out].ms - m_frames[m_mark_in].ms;
         SongTime_t max_delta = m_frames[m_mark_out + 1].ms - m_frames[m_mark_in].ms - 1;
-        float maximum_scale = double(max_delta) / initial_delta;
+        float maximum_scale = static_cast<float>(max_delta) / initial_delta;
         scale = std::min(scale, maximum_scale);
     }
 
     for (auto frame = m_frames.begin() + m_mark_in + 1; frame != m_frames.begin() + m_mark_out + 1; ++frame) {
         SongTime_t difference = frame->ms - m_frames[m_mark_in].ms;
-        difference = std::round((double)difference * scale);
+        difference = std::round(static_cast<double>(difference) * scale);
         frame->ms = std::max(m_frames[m_mark_in].ms + 1, m_frames[m_mark_in].ms + difference);
     }
 

--- a/ReplayEditor/replayengine.hpp
+++ b/ReplayEditor/replayengine.hpp
@@ -48,6 +48,14 @@ struct ReplayFrame {
     {
         return keys & 16;
     }
+
+    ReplayFrame()
+    {
+    }
+
+    ReplayFrame(SongTime_t _ms, float x, float y, int _keys) : p(x, y), ms(_ms), keys(_keys)
+    {
+    }
 };
 
 struct ReplayMetadata {
@@ -108,6 +116,20 @@ class Replay
     void place_mark_all();
     void clear_marks();
     void place_marks_at(I64 mark_in, I64 mark_out);
+
+    bool insert_new_frame(SongTime_t time);
+    bool insert_new_frame_between();
+    bool delete_frames_range();
+
+    bool move_frame(SongTime_t time = 1);
+    bool move_frames_range(SongTime_t time = 1);
+
+    bool center_frame();
+    bool center_frames_range();
+
+    bool scale_frames(float scale);
+
+    void mark_all_frames(bool is_keyboard);
 
     const ReplayMetadata &metadata() const
     {

--- a/ReplayEditor/slider.cpp
+++ b/ReplayEditor/slider.cpp
@@ -359,7 +359,7 @@ void slider_t::draw(SongTime_t ms, SongTime_t start, SongTime_t end, float opaci
     glm::vec2 slider_ball_pos{0.f, 0.f};
     draw_slider_ball = ball_position_at_time(ms, start, end, slider_ball_pos);
 
-    SongTime_t true_slider_end_time = std::max(float(end - last_tick_offset), end - duration() / 2);
+    SongTime_t true_slider_end_time = std::max(static_cast<float>(end - last_tick_offset), end - duration() / 2);
     glm::vec2 true_slider_end_pos{0.f, 0.f};
     auto true_slider_end_size = size * 2.4f;
 

--- a/ReplayEditor/slider.hpp
+++ b/ReplayEditor/slider.hpp
@@ -10,10 +10,6 @@
 struct pos_time_t {
     glm::vec2 pos;
     SongTime_t time;
-
-    pos_time_t(glm::vec2 pos_, SongTime_t time_) : pos(pos_), time(time_)
-    {
-    }
 };
 
 class slider_t

--- a/ReplayEditor/slider.hpp
+++ b/ReplayEditor/slider.hpp
@@ -10,6 +10,10 @@
 struct pos_time_t {
     glm::vec2 pos;
     SongTime_t time;
+
+    pos_time_t(glm::vec2 pos_, SongTime_t time_) : pos(pos_), time(time_)
+    {
+    }
 };
 
 class slider_t
@@ -32,8 +36,9 @@ class slider_t
     }
     glm::vec2 end_pos() const;
     static slider_t *from_def(const char *def, glm::vec2 pos, SongTime_t start, SongTime_t end);
-    void draw(SongTime_t ms, SongTime_t start, SongTime_t end, float opacity);
+    void draw(SongTime_t ms, SongTime_t start, SongTime_t end, float opacity, bool draw_true_slider_end);
     void translate_offset(const glm::vec2 &offset);
     bool ball_position_at_time(SongTime_t ms, SongTime_t start, SongTime_t end, glm::vec2 &out_pos) const;
     bool position_at_time(SongTime_t ms, SongTime_t start, SongTime_t end, glm::vec2 &out_pos) const;
+    bool position_at_time(SongTime_t ms, glm::vec2 &out_pos) const;
 };

--- a/ReplayEditor/stdafx.h
+++ b/ReplayEditor/stdafx.h
@@ -62,6 +62,7 @@ static inline std::ostream &operator<<(std::ostream &o, const std::wstring &s)
 }
 
 #define IS_PRESSED(prevm1, prevm2, currm1, currm2) (!(prevm1) && (currm1) || (!(prevm2) && (currm2)))
+#define IS_PRESSED_INT(prevm1, prevm2, currm1, currm2) ((!(prevm1) && (currm1)) + ((!(prevm2) && (currm2))))
 #define IS_RELEASE(prevm1, prevm2, currm1, currm2) ((prevm1) || (prevm2)) && (!(currm1) && !(currm2));
 
 #define glColorWhite() glColor3f(1.0f, 1.0f, 1.0f)

--- a/ReplayEditor/tools.cpp
+++ b/ReplayEditor/tools.cpp
@@ -133,7 +133,7 @@ void SelectTool::OnMouseMove(const glm::vec2& mouse)
 bool SelectTool::ApplyMutation(replayengine::Replay& replay)
 {
     using ::replayengine::ReplayFrame;
-    const SongTime_t ms = audioengine::handle->get_time();
+    const double ms = audioengine::handle->get_time();
     auto start =
         std::lower_bound(replay.frames().begin(), replay.frames().end(), ms - ui::trail_length, CmpMs<ReplayFrame>());
     auto end = std::lower_bound(replay.frames().begin(), replay.frames().end(), ms, CmpMs<ReplayFrame>());

--- a/ReplayEditor/ui.hpp
+++ b/ReplayEditor/ui.hpp
@@ -6,6 +6,7 @@ namespace ui
 {
 
 void draw(SongTime_t ms);
+void draw_frame_lines(SongTime_t ms);
 void mouse_up(const glm::vec2 &p);
 void mouse_down(const glm::vec2 &p);
 void mouse_move(const glm::vec2 &p);
@@ -15,5 +16,7 @@ void mouse_wheel(const glm::vec2 &p, bool is_up);
 enum class TrailMode { Off, Raw, Hits, num_trail_modes };
 extern TrailMode trail_mode;
 extern SongTime_t trail_length;
-
+extern bool draw_frames_on_timeline;
+extern bool draw_hitwindows_on_timeline;
+extern bool draw_sliderend_range;
 }  // namespace ui

--- a/osuReplayEditor/API.cs
+++ b/osuReplayEditor/API.cs
@@ -294,10 +294,7 @@ namespace osuReplayEditor
         public static extern bool DeviceMarkAllFrames(bool isKeyboard);
 
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern IntPtr GetMapPath();
-
-        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern void FreeBuffer(IntPtr ptr);
+        public static extern void GetMapPath(byte[] buf, ref int len);
 
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool LoadSave(string saveFileName);

--- a/osuReplayEditor/API.cs
+++ b/osuReplayEditor/API.cs
@@ -59,6 +59,24 @@ namespace osuReplayEditor
         public static extern void MouseWheel(float x, float y, bool isUp);
 
         /// <summary>
+        /// sets the setting to draw frames on the timeline as white half-lines
+        /// </summary>
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void SetDrawFramesOnTimeline(bool value);
+
+        /// <summary>
+        /// sets the setting to hitwindows on the timeline
+        /// </summary>
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void SetDrawHitWindows(bool value);
+
+        /// <summary>
+        /// sets the setting to draw range of sliderend assuming player didn't left the sliderball range before
+        /// </summary>
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void SetDrawSliderendRange(bool value);
+
+        /// <summary>
         /// draw the beatmap and cursor data (expects openGL context to be made)
         /// </summary>
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
@@ -120,8 +138,11 @@ namespace osuReplayEditor
         /// jumps ahead or behind the current position
         /// </summary>
         /// <param name="ms">time in miliseconds relative to the current position in the song</param>
+        //[DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        //public static extern void RelJump(int ms);
+
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern void RelJump(int ms);
+        public static extern void RelJump(double ms);
 
         /// <summary>
         /// changes the volume of the audio engine
@@ -155,8 +176,11 @@ namespace osuReplayEditor
         /// gets the current position in the song
         /// </summary>
         /// <returns>time in ms from the beginning of the song</returns>
+        //[DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        //public static extern int GetTime();
+
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
-        public static extern int GetTime();
+        public static extern double GetTime();
 
         /// <summary>
         /// changes the cursor display
@@ -250,6 +274,30 @@ namespace osuReplayEditor
         /// <returns>true if success, false if not (perhaps due to no valid selection)</returns>
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
         public static extern bool SetFrameKeyPress(int mask);
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool MoveFrames(int ms);
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool CenterFrames();
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool ScaleFrames(float scale);
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool AddFrame(int ms = 0);
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool DeleteFrames();
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern bool DeviceMarkAllFrames(bool isKeyboard);
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern IntPtr GetMapPath();
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
+        public static extern void FreeBuffer(IntPtr ptr);
 
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
         public static extern bool LoadSave(string saveFileName);
@@ -412,5 +460,8 @@ namespace osuReplayEditor
 
         [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall)]
         public static extern int CfgGetCursorMode();
+
+        [DllImport("ReplayEditor.dll", CallingConvention = CallingConvention.StdCall, CharSet = CharSet.Unicode)]
+        public static extern bool ChangeHashOfBeatmap(string path);
     }
 }

--- a/osuReplayEditor/MainForm.Designer.cs
+++ b/osuReplayEditor/MainForm.Designer.cs
@@ -1,3 +1,4 @@
+
 namespace osuReplayEditor
 {
     partial class MainForm
@@ -34,6 +35,7 @@ namespace osuReplayEditor
             this.openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.exportAsosrToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.changeReplaysBeatmapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.replayMetadataToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.undoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -52,7 +54,7 @@ namespace osuReplayEditor
             this.playbackRadio075x = new System.Windows.Forms.RadioButton();
             this.playbackRadio100x = new System.Windows.Forms.RadioButton();
             this.playbackRadio150x = new System.Windows.Forms.RadioButton();
-            this.playbackRadio200x = new System.Windows.Forms.RadioButton();
+            this.playbackRadio005x = new System.Windows.Forms.RadioButton();
             this.playbackRadio400x = new System.Windows.Forms.RadioButton();
             this.playbackSpeedPanel = new System.Windows.Forms.Panel();
             this.playbackRadio010x = new System.Windows.Forms.RadioButton();
@@ -125,9 +127,21 @@ namespace osuReplayEditor
             this.label17 = new System.Windows.Forms.Label();
             this.nextObjectBtn = new System.Windows.Forms.Button();
             this.currentHitObjectLabel = new System.Windows.Forms.Label();
+            this.isKeyboardCB = new System.Windows.Forms.CheckBox();
+            this.drawFramesOnTimelineCB = new System.Windows.Forms.CheckBox();
+            this.moveFrameBackBtn = new System.Windows.Forms.Button();
+            this.moveFrameForwardBtn = new System.Windows.Forms.Button();
+            this.centerCurrentFrameBtn = new System.Windows.Forms.Button();
+            this.addFrameBtn = new System.Windows.Forms.Button();
+            this.deleteFrameBtn = new System.Windows.Forms.Button();
+            this.toKeyboardBtn = new System.Windows.Forms.Button();
+            this.openFileDialog2 = new System.Windows.Forms.OpenFileDialog();
+            this.scaleFramesBtn = new System.Windows.Forms.Button();
+            this.scaleFramesUd = new System.Windows.Forms.NumericUpDown();
+            this.drawHitWindowsCB = new System.Windows.Forms.CheckBox();
+            this.drawSliderendRangeCB = new System.Windows.Forms.CheckBox();
             this.timelineControl = new osuReplayEditor.TimelineControl();
             this.canvas = new osuReplayEditor.Canvas();
-            this.isKeyboard = new System.Windows.Forms.CheckBox();
             this.menuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.volumeBar)).BeginInit();
             this.playbackSpeedPanel.SuspendLayout();
@@ -135,10 +149,12 @@ namespace osuReplayEditor
             ((System.ComponentModel.ISupportInitialize)(this.trailLengthBar)).BeginInit();
             this.panel2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.brushRadiusTrackBar)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.scaleFramesUd)).BeginInit();
             this.SuspendLayout();
             // 
             // menuStrip1
             // 
+            this.menuStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
             this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.fileToolStripMenuItem,
             this.replayMetadataToolStripMenuItem,
@@ -148,7 +164,7 @@ namespace osuReplayEditor
             this.githubToolStripMenuItem});
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.Size = new System.Drawing.Size(1184, 24);
+            this.menuStrip1.Size = new System.Drawing.Size(1579, 30);
             this.menuStrip1.TabIndex = 1;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -157,15 +173,16 @@ namespace osuReplayEditor
             this.fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.openToolStripMenuItem,
             this.saveToolStripMenuItem,
-            this.exportAsosrToolStripMenuItem});
+            this.exportAsosrToolStripMenuItem,
+            this.changeReplaysBeatmapToolStripMenuItem});
             this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
-            this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            this.fileToolStripMenuItem.Size = new System.Drawing.Size(46, 26);
             this.fileToolStripMenuItem.Text = "File";
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(257, 26);
             this.openToolStripMenuItem.Text = "Open";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -173,21 +190,28 @@ namespace osuReplayEditor
             // 
             this.saveToolStripMenuItem.Enabled = false;
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(257, 26);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // exportAsosrToolStripMenuItem
             // 
             this.exportAsosrToolStripMenuItem.Name = "exportAsosrToolStripMenuItem";
-            this.exportAsosrToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+            this.exportAsosrToolStripMenuItem.Size = new System.Drawing.Size(257, 26);
             this.exportAsosrToolStripMenuItem.Text = "Export as .osr";
             this.exportAsosrToolStripMenuItem.Click += new System.EventHandler(this.exportAsosrToolStripMenuItem_Click);
+            // 
+            // changeReplaysBeatmapToolStripMenuItem
+            // 
+            this.changeReplaysBeatmapToolStripMenuItem.Name = "changeReplaysBeatmapToolStripMenuItem";
+            this.changeReplaysBeatmapToolStripMenuItem.Size = new System.Drawing.Size(257, 26);
+            this.changeReplaysBeatmapToolStripMenuItem.Text = "Change replays beatmap";
+            this.changeReplaysBeatmapToolStripMenuItem.Click += new System.EventHandler(this.changeReplaysBeatmapToolStripMenuItem_Click);
             // 
             // replayMetadataToolStripMenuItem
             // 
             this.replayMetadataToolStripMenuItem.Name = "replayMetadataToolStripMenuItem";
-            this.replayMetadataToolStripMenuItem.Size = new System.Drawing.Size(107, 20);
+            this.replayMetadataToolStripMenuItem.Size = new System.Drawing.Size(136, 26);
             this.replayMetadataToolStripMenuItem.Text = "Replay Metadata";
             this.replayMetadataToolStripMenuItem.Click += new System.EventHandler(this.replayMetadataToolStripMenuItem_Click);
             // 
@@ -197,34 +221,34 @@ namespace osuReplayEditor
             this.undoToolStripMenuItem,
             this.redoToolStripMenuItem});
             this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
+            this.editToolStripMenuItem.Size = new System.Drawing.Size(49, 26);
             this.editToolStripMenuItem.Text = "Edit";
             // 
             // undoToolStripMenuItem
             // 
             this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
-            this.undoToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.undoToolStripMenuItem.Size = new System.Drawing.Size(128, 26);
             this.undoToolStripMenuItem.Text = "Undo";
             this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
             // 
             // redoToolStripMenuItem
             // 
             this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
-            this.redoToolStripMenuItem.Size = new System.Drawing.Size(103, 22);
+            this.redoToolStripMenuItem.Size = new System.Drawing.Size(128, 26);
             this.redoToolStripMenuItem.Text = "Redo";
             this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
             // 
             // quickLoadToolStripMenuItem
             // 
             this.quickLoadToolStripMenuItem.Name = "quickLoadToolStripMenuItem";
-            this.quickLoadToolStripMenuItem.Size = new System.Drawing.Size(79, 20);
+            this.quickLoadToolStripMenuItem.Size = new System.Drawing.Size(97, 26);
             this.quickLoadToolStripMenuItem.Text = "Quick Load";
             this.quickLoadToolStripMenuItem.DropDownOpening += new System.EventHandler(this.quickLoadToolStripMenuItem_DropDownOpening);
             // 
             // configToolStripMenuItem
             // 
             this.configToolStripMenuItem.Name = "configToolStripMenuItem";
-            this.configToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
+            this.configToolStripMenuItem.Size = new System.Drawing.Size(67, 26);
             this.configToolStripMenuItem.Text = "Config";
             this.configToolStripMenuItem.Click += new System.EventHandler(this.configToolStripMenuItem_Click);
             // 
@@ -235,37 +259,38 @@ namespace osuReplayEditor
             this.keybindReferenceToolStripMenuItem,
             this.analyzeAccTraceToolStripMenuItem});
             this.githubToolStripMenuItem.Name = "githubToolStripMenuItem";
-            this.githubToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
+            this.githubToolStripMenuItem.Size = new System.Drawing.Size(55, 26);
             this.githubToolStripMenuItem.Text = "Help";
             // 
             // githubToolStripMenuItem1
             // 
             this.githubToolStripMenuItem1.Name = "githubToolStripMenuItem1";
-            this.githubToolStripMenuItem1.Size = new System.Drawing.Size(180, 22);
+            this.githubToolStripMenuItem1.Size = new System.Drawing.Size(216, 26);
             this.githubToolStripMenuItem1.Text = "Github";
             this.githubToolStripMenuItem1.Click += new System.EventHandler(this.githubToolStripMenuItem1_Click);
             // 
             // keybindReferenceToolStripMenuItem
             // 
             this.keybindReferenceToolStripMenuItem.Name = "keybindReferenceToolStripMenuItem";
-            this.keybindReferenceToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.keybindReferenceToolStripMenuItem.Size = new System.Drawing.Size(216, 26);
             this.keybindReferenceToolStripMenuItem.Text = "Keybind Reference";
             this.keybindReferenceToolStripMenuItem.Click += new System.EventHandler(this.keybindReferenceToolStripMenuItem_Click);
             // 
             // analyzeAccTraceToolStripMenuItem
             // 
             this.analyzeAccTraceToolStripMenuItem.Name = "analyzeAccTraceToolStripMenuItem";
-            this.analyzeAccTraceToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.analyzeAccTraceToolStripMenuItem.Size = new System.Drawing.Size(216, 26);
             this.analyzeAccTraceToolStripMenuItem.Text = "Analyze Acc Trace";
             this.analyzeAccTraceToolStripMenuItem.Click += new System.EventHandler(this.analyzeAccTraceToolStripMenuItem_Click);
             // 
             // volumeBar
             // 
             this.volumeBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.volumeBar.Location = new System.Drawing.Point(1123, 52);
+            this.volumeBar.Location = new System.Drawing.Point(1497, 64);
+            this.volumeBar.Margin = new System.Windows.Forms.Padding(4);
             this.volumeBar.Name = "volumeBar";
             this.volumeBar.Orientation = System.Windows.Forms.Orientation.Vertical;
-            this.volumeBar.Size = new System.Drawing.Size(45, 431);
+            this.volumeBar.Size = new System.Drawing.Size(56, 530);
             this.volumeBar.TabIndex = 2;
             this.volumeBar.TickStyle = System.Windows.Forms.TickStyle.Both;
             this.volumeBar.Value = 2;
@@ -275,18 +300,20 @@ namespace osuReplayEditor
             // 
             this.volumeLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.volumeLabel.AutoSize = true;
-            this.volumeLabel.Location = new System.Drawing.Point(1112, 36);
+            this.volumeLabel.Location = new System.Drawing.Point(1483, 44);
+            this.volumeLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.volumeLabel.Name = "volumeLabel";
-            this.volumeLabel.Size = new System.Drawing.Size(71, 13);
+            this.volumeLabel.Size = new System.Drawing.Size(89, 16);
             this.volumeLabel.TabIndex = 3;
             this.volumeLabel.Text = "Volume 100%";
             // 
             // playbackSpeedLabel
             // 
             this.playbackSpeedLabel.AutoSize = true;
-            this.playbackSpeedLabel.Location = new System.Drawing.Point(7, 36);
+            this.playbackSpeedLabel.Location = new System.Drawing.Point(9, 44);
+            this.playbackSpeedLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.playbackSpeedLabel.Name = "playbackSpeedLabel";
-            this.playbackSpeedLabel.Size = new System.Drawing.Size(85, 13);
+            this.playbackSpeedLabel.Size = new System.Drawing.Size(108, 16);
             this.playbackSpeedLabel.TabIndex = 4;
             this.playbackSpeedLabel.Text = "Playback Speed";
             // 
@@ -296,9 +323,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio025x.AutoSize = true;
-            this.playbackRadio025x.Location = new System.Drawing.Point(10, 34);
+            this.playbackRadio025x.Location = new System.Drawing.Point(12, 72);
+            this.playbackRadio025x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio025x.Name = "playbackRadio025x";
-            this.playbackRadio025x.Size = new System.Drawing.Size(54, 17);
+            this.playbackRadio025x.Size = new System.Drawing.Size(61, 20);
             this.playbackRadio025x.TabIndex = 5;
             this.playbackRadio025x.Text = "0.25 x";
             this.playbackRadio025x.UseVisualStyleBackColor = true;
@@ -310,9 +338,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio050x.AutoSize = true;
-            this.playbackRadio050x.Location = new System.Drawing.Point(10, 57);
+            this.playbackRadio050x.Location = new System.Drawing.Point(12, 100);
+            this.playbackRadio050x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio050x.Name = "playbackRadio050x";
-            this.playbackRadio050x.Size = new System.Drawing.Size(54, 17);
+            this.playbackRadio050x.Size = new System.Drawing.Size(61, 20);
             this.playbackRadio050x.TabIndex = 6;
             this.playbackRadio050x.Text = "0.50 x";
             this.playbackRadio050x.UseVisualStyleBackColor = true;
@@ -324,9 +353,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio075x.AutoSize = true;
-            this.playbackRadio075x.Location = new System.Drawing.Point(10, 80);
+            this.playbackRadio075x.Location = new System.Drawing.Point(12, 128);
+            this.playbackRadio075x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio075x.Name = "playbackRadio075x";
-            this.playbackRadio075x.Size = new System.Drawing.Size(78, 17);
+            this.playbackRadio075x.Size = new System.Drawing.Size(91, 20);
             this.playbackRadio075x.TabIndex = 7;
             this.playbackRadio075x.Text = "0.75 x (HT)";
             this.playbackRadio075x.UseVisualStyleBackColor = true;
@@ -339,9 +369,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio100x.AutoSize = true;
             this.playbackRadio100x.Checked = true;
-            this.playbackRadio100x.Location = new System.Drawing.Point(10, 103);
+            this.playbackRadio100x.Location = new System.Drawing.Point(12, 157);
+            this.playbackRadio100x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio100x.Name = "playbackRadio100x";
-            this.playbackRadio100x.Size = new System.Drawing.Size(54, 17);
+            this.playbackRadio100x.Size = new System.Drawing.Size(61, 20);
             this.playbackRadio100x.TabIndex = 8;
             this.playbackRadio100x.TabStop = true;
             this.playbackRadio100x.Text = "1.00 x";
@@ -354,27 +385,29 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio150x.AutoSize = true;
-            this.playbackRadio150x.Location = new System.Drawing.Point(10, 126);
+            this.playbackRadio150x.Location = new System.Drawing.Point(12, 185);
+            this.playbackRadio150x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio150x.Name = "playbackRadio150x";
-            this.playbackRadio150x.Size = new System.Drawing.Size(78, 17);
+            this.playbackRadio150x.Size = new System.Drawing.Size(91, 20);
             this.playbackRadio150x.TabIndex = 9;
             this.playbackRadio150x.Text = "1.50 x (DT)";
             this.playbackRadio150x.UseVisualStyleBackColor = true;
             this.playbackRadio150x.CheckedChanged += new System.EventHandler(this.playbackRadio150x_CheckedChanged);
             // 
-            // playbackRadio200x
+            // playbackRadio005x
             // 
-            this.playbackRadio200x.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            this.playbackRadio005x.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.playbackRadio200x.AutoSize = true;
-            this.playbackRadio200x.Location = new System.Drawing.Point(10, 149);
-            this.playbackRadio200x.Name = "playbackRadio200x";
-            this.playbackRadio200x.Size = new System.Drawing.Size(54, 17);
-            this.playbackRadio200x.TabIndex = 10;
-            this.playbackRadio200x.Text = "2.00 x";
-            this.playbackRadio200x.UseVisualStyleBackColor = true;
-            this.playbackRadio200x.CheckedChanged += new System.EventHandler(this.playbackRadio200x_CheckedChanged);
+            this.playbackRadio005x.AutoSize = true;
+            this.playbackRadio005x.Location = new System.Drawing.Point(12, 16);
+            this.playbackRadio005x.Margin = new System.Windows.Forms.Padding(4);
+            this.playbackRadio005x.Name = "playbackRadio005x";
+            this.playbackRadio005x.Size = new System.Drawing.Size(61, 20);
+            this.playbackRadio005x.TabIndex = 10;
+            this.playbackRadio005x.Text = "0.05 x";
+            this.playbackRadio005x.UseVisualStyleBackColor = true;
+            this.playbackRadio005x.CheckedChanged += new System.EventHandler(this.playbackRadio005x_CheckedChanged);
             // 
             // playbackRadio400x
             // 
@@ -382,9 +415,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio400x.AutoSize = true;
-            this.playbackRadio400x.Location = new System.Drawing.Point(10, 172);
+            this.playbackRadio400x.Location = new System.Drawing.Point(13, 212);
+            this.playbackRadio400x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio400x.Name = "playbackRadio400x";
-            this.playbackRadio400x.Size = new System.Drawing.Size(54, 17);
+            this.playbackRadio400x.Size = new System.Drawing.Size(61, 20);
             this.playbackRadio400x.TabIndex = 11;
             this.playbackRadio400x.Text = "4.00 x";
             this.playbackRadio400x.UseVisualStyleBackColor = true;
@@ -396,13 +430,14 @@ namespace osuReplayEditor
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio400x);
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio010x);
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio025x);
-            this.playbackSpeedPanel.Controls.Add(this.playbackRadio200x);
+            this.playbackSpeedPanel.Controls.Add(this.playbackRadio005x);
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio050x);
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio150x);
             this.playbackSpeedPanel.Controls.Add(this.playbackRadio100x);
-            this.playbackSpeedPanel.Location = new System.Drawing.Point(0, 52);
+            this.playbackSpeedPanel.Location = new System.Drawing.Point(0, 64);
+            this.playbackSpeedPanel.Margin = new System.Windows.Forms.Padding(4);
             this.playbackSpeedPanel.Name = "playbackSpeedPanel";
-            this.playbackSpeedPanel.Size = new System.Drawing.Size(94, 195);
+            this.playbackSpeedPanel.Size = new System.Drawing.Size(125, 240);
             this.playbackSpeedPanel.TabIndex = 12;
             // 
             // playbackRadio010x
@@ -411,9 +446,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.playbackRadio010x.AutoSize = true;
-            this.playbackRadio010x.Location = new System.Drawing.Point(10, 11);
+            this.playbackRadio010x.Location = new System.Drawing.Point(12, 44);
+            this.playbackRadio010x.Margin = new System.Windows.Forms.Padding(4);
             this.playbackRadio010x.Name = "playbackRadio010x";
-            this.playbackRadio010x.Size = new System.Drawing.Size(54, 17);
+            this.playbackRadio010x.Size = new System.Drawing.Size(61, 20);
             this.playbackRadio010x.TabIndex = 5;
             this.playbackRadio010x.Text = "0.10 x";
             this.playbackRadio010x.UseVisualStyleBackColor = true;
@@ -422,9 +458,10 @@ namespace osuReplayEditor
             // muteBtn
             // 
             this.muteBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.muteBtn.Location = new System.Drawing.Point(1106, 489);
+            this.muteBtn.Location = new System.Drawing.Point(1475, 602);
+            this.muteBtn.Margin = new System.Windows.Forms.Padding(4);
             this.muteBtn.Name = "muteBtn";
-            this.muteBtn.Size = new System.Drawing.Size(75, 23);
+            this.muteBtn.Size = new System.Drawing.Size(100, 28);
             this.muteBtn.TabIndex = 13;
             this.muteBtn.Text = "Mute";
             this.muteBtn.UseVisualStyleBackColor = true;
@@ -435,9 +472,10 @@ namespace osuReplayEditor
             this.panel1.Controls.Add(this.cursorRadioPresses);
             this.panel1.Controls.Add(this.cursorRadioNormal);
             this.panel1.Controls.Add(this.cursorRadioKeys);
-            this.panel1.Location = new System.Drawing.Point(0, 273);
+            this.panel1.Location = new System.Drawing.Point(0, 336);
+            this.panel1.Margin = new System.Windows.Forms.Padding(4);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(94, 86);
+            this.panel1.Size = new System.Drawing.Size(125, 106);
             this.panel1.TabIndex = 15;
             // 
             // cursorRadioPresses
@@ -447,9 +485,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cursorRadioPresses.AutoSize = true;
             this.cursorRadioPresses.Checked = true;
-            this.cursorRadioPresses.Location = new System.Drawing.Point(10, 59);
+            this.cursorRadioPresses.Location = new System.Drawing.Point(13, 73);
+            this.cursorRadioPresses.Margin = new System.Windows.Forms.Padding(4);
             this.cursorRadioPresses.Name = "cursorRadioPresses";
-            this.cursorRadioPresses.Size = new System.Drawing.Size(62, 17);
+            this.cursorRadioPresses.Size = new System.Drawing.Size(78, 20);
             this.cursorRadioPresses.TabIndex = 7;
             this.cursorRadioPresses.TabStop = true;
             this.cursorRadioPresses.Text = "Presses";
@@ -462,9 +501,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cursorRadioNormal.AutoSize = true;
-            this.cursorRadioNormal.Location = new System.Drawing.Point(10, 13);
+            this.cursorRadioNormal.Location = new System.Drawing.Point(13, 16);
+            this.cursorRadioNormal.Margin = new System.Windows.Forms.Padding(4);
             this.cursorRadioNormal.Name = "cursorRadioNormal";
-            this.cursorRadioNormal.Size = new System.Drawing.Size(58, 17);
+            this.cursorRadioNormal.Size = new System.Drawing.Size(72, 20);
             this.cursorRadioNormal.TabIndex = 5;
             this.cursorRadioNormal.Text = "Normal";
             this.cursorRadioNormal.UseVisualStyleBackColor = true;
@@ -476,9 +516,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.cursorRadioKeys.AutoSize = true;
-            this.cursorRadioKeys.Location = new System.Drawing.Point(10, 36);
+            this.cursorRadioKeys.Location = new System.Drawing.Point(13, 44);
+            this.cursorRadioKeys.Margin = new System.Windows.Forms.Padding(4);
             this.cursorRadioKeys.Name = "cursorRadioKeys";
-            this.cursorRadioKeys.Size = new System.Drawing.Size(48, 17);
+            this.cursorRadioKeys.Size = new System.Drawing.Size(58, 20);
             this.cursorRadioKeys.TabIndex = 6;
             this.cursorRadioKeys.Text = "Keys";
             this.cursorRadioKeys.UseVisualStyleBackColor = true;
@@ -487,18 +528,20 @@ namespace osuReplayEditor
             // cursorTrailLabel
             // 
             this.cursorTrailLabel.AutoSize = true;
-            this.cursorTrailLabel.Location = new System.Drawing.Point(7, 257);
+            this.cursorTrailLabel.Location = new System.Drawing.Point(9, 316);
+            this.cursorTrailLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cursorTrailLabel.Name = "cursorTrailLabel";
-            this.cursorTrailLabel.Size = new System.Drawing.Size(37, 13);
+            this.cursorTrailLabel.Size = new System.Drawing.Size(46, 16);
             this.cursorTrailLabel.TabIndex = 14;
             this.cursorTrailLabel.Text = "Cursor";
             // 
             // togglePauseBtn
             // 
             this.togglePauseBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.togglePauseBtn.Location = new System.Drawing.Point(100, 467);
+            this.togglePauseBtn.Location = new System.Drawing.Point(133, 575);
+            this.togglePauseBtn.Margin = new System.Windows.Forms.Padding(4);
             this.togglePauseBtn.Name = "togglePauseBtn";
-            this.togglePauseBtn.Size = new System.Drawing.Size(75, 23);
+            this.togglePauseBtn.Size = new System.Drawing.Size(100, 28);
             this.togglePauseBtn.TabIndex = 17;
             this.togglePauseBtn.Text = "Play";
             this.togglePauseBtn.UseVisualStyleBackColor = true;
@@ -508,9 +551,10 @@ namespace osuReplayEditor
             // 
             this.songTimeLabelLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.songTimeLabelLabel.AutoSize = true;
-            this.songTimeLabelLabel.Location = new System.Drawing.Point(181, 472);
+            this.songTimeLabelLabel.Location = new System.Drawing.Point(241, 581);
+            this.songTimeLabelLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.songTimeLabelLabel.Name = "songTimeLabelLabel";
-            this.songTimeLabelLabel.Size = new System.Drawing.Size(64, 13);
+            this.songTimeLabelLabel.Size = new System.Drawing.Size(79, 16);
             this.songTimeLabelLabel.TabIndex = 18;
             this.songTimeLabelLabel.Text = "Song Time: ";
             // 
@@ -518,18 +562,20 @@ namespace osuReplayEditor
             // 
             this.songTimeLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.songTimeLabel.AutoSize = true;
-            this.songTimeLabel.Location = new System.Drawing.Point(239, 472);
+            this.songTimeLabel.Location = new System.Drawing.Point(319, 581);
+            this.songTimeLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.songTimeLabel.Name = "songTimeLabel";
-            this.songTimeLabel.Size = new System.Drawing.Size(13, 13);
+            this.songTimeLabel.Size = new System.Drawing.Size(15, 16);
             this.songTimeLabel.TabIndex = 19;
             this.songTimeLabel.Text = "--";
             // 
             // markInBtn
             // 
             this.markInBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.markInBtn.Location = new System.Drawing.Point(198, 501);
+            this.markInBtn.Location = new System.Drawing.Point(264, 617);
+            this.markInBtn.Margin = new System.Windows.Forms.Padding(4);
             this.markInBtn.Name = "markInBtn";
-            this.markInBtn.Size = new System.Drawing.Size(75, 23);
+            this.markInBtn.Size = new System.Drawing.Size(100, 28);
             this.markInBtn.TabIndex = 22;
             this.markInBtn.Text = "Mark In";
             this.markInBtn.UseVisualStyleBackColor = true;
@@ -538,9 +584,10 @@ namespace osuReplayEditor
             // markOutBtn
             // 
             this.markOutBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.markOutBtn.Location = new System.Drawing.Point(279, 501);
+            this.markOutBtn.Location = new System.Drawing.Point(372, 617);
+            this.markOutBtn.Margin = new System.Windows.Forms.Padding(4);
             this.markOutBtn.Name = "markOutBtn";
-            this.markOutBtn.Size = new System.Drawing.Size(75, 23);
+            this.markOutBtn.Size = new System.Drawing.Size(100, 28);
             this.markOutBtn.TabIndex = 23;
             this.markOutBtn.Text = "Mark Out";
             this.markOutBtn.UseVisualStyleBackColor = true;
@@ -549,9 +596,10 @@ namespace osuReplayEditor
             // markMidBtn
             // 
             this.markMidBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.markMidBtn.Location = new System.Drawing.Point(360, 501);
+            this.markMidBtn.Location = new System.Drawing.Point(480, 617);
+            this.markMidBtn.Margin = new System.Windows.Forms.Padding(4);
             this.markMidBtn.Name = "markMidBtn";
-            this.markMidBtn.Size = new System.Drawing.Size(75, 23);
+            this.markMidBtn.Size = new System.Drawing.Size(100, 28);
             this.markMidBtn.TabIndex = 24;
             this.markMidBtn.Text = "Mark Mid";
             this.markMidBtn.UseVisualStyleBackColor = true;
@@ -560,9 +608,10 @@ namespace osuReplayEditor
             // clearMarksBtn
             // 
             this.clearMarksBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.clearMarksBtn.Location = new System.Drawing.Point(522, 501);
+            this.clearMarksBtn.Location = new System.Drawing.Point(696, 617);
+            this.clearMarksBtn.Margin = new System.Windows.Forms.Padding(4);
             this.clearMarksBtn.Name = "clearMarksBtn";
-            this.clearMarksBtn.Size = new System.Drawing.Size(75, 23);
+            this.clearMarksBtn.Size = new System.Drawing.Size(100, 28);
             this.clearMarksBtn.TabIndex = 25;
             this.clearMarksBtn.Text = "Clear Marks";
             this.clearMarksBtn.UseVisualStyleBackColor = true;
@@ -572,9 +621,10 @@ namespace osuReplayEditor
             // 
             this.markerInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.markerInfoLabel.AutoSize = true;
-            this.markerInfoLabel.Location = new System.Drawing.Point(97, 506);
+            this.markerInfoLabel.Location = new System.Drawing.Point(129, 623);
+            this.markerInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.markerInfoLabel.Name = "markerInfoLabel";
-            this.markerInfoLabel.Size = new System.Drawing.Size(95, 13);
+            this.markerInfoLabel.Size = new System.Drawing.Size(115, 16);
             this.markerInfoLabel.TabIndex = 26;
             this.markerInfoLabel.Text = "Markers / Anchors";
             // 
@@ -582,18 +632,20 @@ namespace osuReplayEditor
             // 
             this.keypressInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.keypressInfoLabel.AutoSize = true;
-            this.keypressInfoLabel.Location = new System.Drawing.Point(127, 531);
+            this.keypressInfoLabel.Location = new System.Drawing.Point(169, 654);
+            this.keypressInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.keypressInfoLabel.Name = "keypressInfoLabel";
-            this.keypressInfoLabel.Size = new System.Drawing.Size(65, 13);
+            this.keypressInfoLabel.Size = new System.Drawing.Size(83, 16);
             this.keypressInfoLabel.TabIndex = 28;
             this.keypressInfoLabel.Text = "Key Presses";
             // 
             // markAllBtn
             // 
             this.markAllBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.markAllBtn.Location = new System.Drawing.Point(441, 501);
+            this.markAllBtn.Location = new System.Drawing.Point(588, 617);
+            this.markAllBtn.Margin = new System.Windows.Forms.Padding(4);
             this.markAllBtn.Name = "markAllBtn";
-            this.markAllBtn.Size = new System.Drawing.Size(75, 23);
+            this.markAllBtn.Size = new System.Drawing.Size(100, 28);
             this.markAllBtn.TabIndex = 29;
             this.markAllBtn.Text = "Mark All";
             this.markAllBtn.UseVisualStyleBackColor = true;
@@ -602,9 +654,10 @@ namespace osuReplayEditor
             // keyPress1Btn
             // 
             this.keyPress1Btn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.keyPress1Btn.Location = new System.Drawing.Point(279, 531);
+            this.keyPress1Btn.Location = new System.Drawing.Point(372, 654);
+            this.keyPress1Btn.Margin = new System.Windows.Forms.Padding(4);
             this.keyPress1Btn.Name = "keyPress1Btn";
-            this.keyPress1Btn.Size = new System.Drawing.Size(75, 23);
+            this.keyPress1Btn.Size = new System.Drawing.Size(100, 28);
             this.keyPress1Btn.TabIndex = 34;
             this.keyPress1Btn.Text = "Key 1";
             this.keyPress1Btn.UseVisualStyleBackColor = true;
@@ -613,9 +666,10 @@ namespace osuReplayEditor
             // keyPress2Btn
             // 
             this.keyPress2Btn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.keyPress2Btn.Location = new System.Drawing.Point(360, 531);
+            this.keyPress2Btn.Location = new System.Drawing.Point(480, 654);
+            this.keyPress2Btn.Margin = new System.Windows.Forms.Padding(4);
             this.keyPress2Btn.Name = "keyPress2Btn";
-            this.keyPress2Btn.Size = new System.Drawing.Size(75, 23);
+            this.keyPress2Btn.Size = new System.Drawing.Size(100, 28);
             this.keyPress2Btn.TabIndex = 33;
             this.keyPress2Btn.Text = "Key 2";
             this.keyPress2Btn.UseVisualStyleBackColor = true;
@@ -624,9 +678,10 @@ namespace osuReplayEditor
             // keyPress12Btn
             // 
             this.keyPress12Btn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.keyPress12Btn.Location = new System.Drawing.Point(441, 531);
+            this.keyPress12Btn.Location = new System.Drawing.Point(588, 654);
+            this.keyPress12Btn.Margin = new System.Windows.Forms.Padding(4);
             this.keyPress12Btn.Name = "keyPress12Btn";
-            this.keyPress12Btn.Size = new System.Drawing.Size(75, 23);
+            this.keyPress12Btn.Size = new System.Drawing.Size(100, 28);
             this.keyPress12Btn.TabIndex = 31;
             this.keyPress12Btn.Text = "Key 1 + 2";
             this.keyPress12Btn.UseVisualStyleBackColor = true;
@@ -635,9 +690,10 @@ namespace osuReplayEditor
             // keyPressNoneBtn
             // 
             this.keyPressNoneBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.keyPressNoneBtn.Location = new System.Drawing.Point(198, 531);
+            this.keyPressNoneBtn.Location = new System.Drawing.Point(264, 654);
+            this.keyPressNoneBtn.Margin = new System.Windows.Forms.Padding(4);
             this.keyPressNoneBtn.Name = "keyPressNoneBtn";
-            this.keyPressNoneBtn.Size = new System.Drawing.Size(75, 23);
+            this.keyPressNoneBtn.Size = new System.Drawing.Size(100, 28);
             this.keyPressNoneBtn.TabIndex = 30;
             this.keyPressNoneBtn.Text = "None";
             this.keyPressNoneBtn.UseVisualStyleBackColor = true;
@@ -646,11 +702,12 @@ namespace osuReplayEditor
             // trailLengthBar
             // 
             this.trailLengthBar.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.trailLengthBar.Location = new System.Drawing.Point(198, 559);
+            this.trailLengthBar.Location = new System.Drawing.Point(264, 688);
+            this.trailLengthBar.Margin = new System.Windows.Forms.Padding(4);
             this.trailLengthBar.Maximum = 30;
             this.trailLengthBar.Minimum = 1;
             this.trailLengthBar.Name = "trailLengthBar";
-            this.trailLengthBar.Size = new System.Drawing.Size(399, 45);
+            this.trailLengthBar.Size = new System.Drawing.Size(532, 56);
             this.trailLengthBar.TabIndex = 35;
             this.trailLengthBar.Value = 10;
             this.trailLengthBar.Scroll += new System.EventHandler(this.trailLengthBar_Scroll);
@@ -659,9 +716,10 @@ namespace osuReplayEditor
             // 
             this.trailLengthInfoLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.trailLengthInfoLabel.AutoSize = true;
-            this.trailLengthInfoLabel.Location = new System.Drawing.Point(96, 559);
+            this.trailLengthInfoLabel.Location = new System.Drawing.Point(128, 688);
+            this.trailLengthInfoLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.trailLengthInfoLabel.Name = "trailLengthInfoLabel";
-            this.trailLengthInfoLabel.Size = new System.Drawing.Size(96, 13);
+            this.trailLengthInfoLabel.Size = new System.Drawing.Size(119, 16);
             this.trailLengthInfoLabel.TabIndex = 36;
             this.trailLengthInfoLabel.Text = "Cursor Trail Length";
             // 
@@ -669,9 +727,10 @@ namespace osuReplayEditor
             // 
             this.cursorTrailValueLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.cursorTrailValueLabel.AutoSize = true;
-            this.cursorTrailValueLabel.Location = new System.Drawing.Point(603, 569);
+            this.cursorTrailValueLabel.Location = new System.Drawing.Point(804, 700);
+            this.cursorTrailValueLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.cursorTrailValueLabel.Name = "cursorTrailValueLabel";
-            this.cursorTrailValueLabel.Size = new System.Drawing.Size(33, 13);
+            this.cursorTrailValueLabel.Size = new System.Drawing.Size(39, 16);
             this.cursorTrailValueLabel.TabIndex = 37;
             this.cursorTrailValueLabel.Text = "1 sec";
             // 
@@ -679,6 +738,7 @@ namespace osuReplayEditor
             // 
             this.openFileDialog1.FileName = "replay.osr";
             this.openFileDialog1.Filter = "osu! Replay Files (*.osr)|*.osr|All files (*.*)|*.*";
+            this.openFileDialog1.RestoreDirectory = true;
             this.openFileDialog1.FileOk += new System.ComponentModel.CancelEventHandler(this.openFileDialog1_FileOk);
             // 
             // saveFileDialog1
@@ -689,9 +749,10 @@ namespace osuReplayEditor
             // flipBeatmapBtn
             // 
             this.flipBeatmapBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.flipBeatmapBtn.Location = new System.Drawing.Point(649, 501);
+            this.flipBeatmapBtn.Location = new System.Drawing.Point(871, 595);
+            this.flipBeatmapBtn.Margin = new System.Windows.Forms.Padding(4);
             this.flipBeatmapBtn.Name = "flipBeatmapBtn";
-            this.flipBeatmapBtn.Size = new System.Drawing.Size(99, 23);
+            this.flipBeatmapBtn.Size = new System.Drawing.Size(132, 28);
             this.flipBeatmapBtn.TabIndex = 38;
             this.flipBeatmapBtn.Text = "Flip Beatmap";
             this.flipBeatmapBtn.UseVisualStyleBackColor = true;
@@ -700,9 +761,10 @@ namespace osuReplayEditor
             // flipCursorDataBtn
             // 
             this.flipCursorDataBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.flipCursorDataBtn.Location = new System.Drawing.Point(649, 531);
+            this.flipCursorDataBtn.Location = new System.Drawing.Point(871, 632);
+            this.flipCursorDataBtn.Margin = new System.Windows.Forms.Padding(4);
             this.flipCursorDataBtn.Name = "flipCursorDataBtn";
-            this.flipCursorDataBtn.Size = new System.Drawing.Size(99, 23);
+            this.flipCursorDataBtn.Size = new System.Drawing.Size(132, 28);
             this.flipCursorDataBtn.TabIndex = 39;
             this.flipCursorDataBtn.Text = "Flip Cursor Data";
             this.flipCursorDataBtn.UseVisualStyleBackColor = true;
@@ -712,9 +774,10 @@ namespace osuReplayEditor
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(646, 485);
+            this.label1.Location = new System.Drawing.Point(867, 575);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(112, 13);
+            this.label1.Size = new System.Drawing.Size(143, 16);
             this.label1.TabIndex = 26;
             this.label1.Text = "Hardrock Compatibility";
             // 
@@ -722,18 +785,20 @@ namespace osuReplayEditor
             // 
             this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(96, 615);
+            this.label2.Location = new System.Drawing.Point(128, 757);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(158, 13);
+            this.label2.Size = new System.Drawing.Size(190, 16);
             this.label2.TabIndex = 40;
             this.label2.Text = "Pan / Zoom (Right click / scroll)";
             // 
             // zoomPanResetBtn
             // 
             this.zoomPanResetBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.zoomPanResetBtn.Location = new System.Drawing.Point(279, 610);
+            this.zoomPanResetBtn.Location = new System.Drawing.Point(355, 751);
+            this.zoomPanResetBtn.Margin = new System.Windows.Forms.Padding(4);
             this.zoomPanResetBtn.Name = "zoomPanResetBtn";
-            this.zoomPanResetBtn.Size = new System.Drawing.Size(75, 23);
+            this.zoomPanResetBtn.Size = new System.Drawing.Size(100, 28);
             this.zoomPanResetBtn.TabIndex = 22;
             this.zoomPanResetBtn.Text = "Reset";
             this.zoomPanResetBtn.UseVisualStyleBackColor = true;
@@ -742,9 +807,10 @@ namespace osuReplayEditor
             // zoomInBtn
             // 
             this.zoomInBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.zoomInBtn.Location = new System.Drawing.Point(360, 610);
+            this.zoomInBtn.Location = new System.Drawing.Point(463, 751);
+            this.zoomInBtn.Margin = new System.Windows.Forms.Padding(4);
             this.zoomInBtn.Name = "zoomInBtn";
-            this.zoomInBtn.Size = new System.Drawing.Size(75, 23);
+            this.zoomInBtn.Size = new System.Drawing.Size(100, 28);
             this.zoomInBtn.TabIndex = 22;
             this.zoomInBtn.Text = "Zoom In";
             this.zoomInBtn.UseVisualStyleBackColor = true;
@@ -753,9 +819,10 @@ namespace osuReplayEditor
             // zoomOutBtn
             // 
             this.zoomOutBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.zoomOutBtn.Location = new System.Drawing.Point(441, 610);
+            this.zoomOutBtn.Location = new System.Drawing.Point(571, 751);
+            this.zoomOutBtn.Margin = new System.Windows.Forms.Padding(4);
             this.zoomOutBtn.Name = "zoomOutBtn";
-            this.zoomOutBtn.Size = new System.Drawing.Size(75, 23);
+            this.zoomOutBtn.Size = new System.Drawing.Size(100, 28);
             this.zoomOutBtn.TabIndex = 22;
             this.zoomOutBtn.Text = "Zoom Out";
             this.zoomOutBtn.UseVisualStyleBackColor = true;
@@ -765,9 +832,10 @@ namespace osuReplayEditor
             // 
             this.updateTimestampCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.updateTimestampCB.AutoSize = true;
-            this.updateTimestampCB.Location = new System.Drawing.Point(649, 581);
+            this.updateTimestampCB.Location = new System.Drawing.Point(871, 694);
+            this.updateTimestampCB.Margin = new System.Windows.Forms.Padding(4);
             this.updateTimestampCB.Name = "updateTimestampCB";
-            this.updateTimestampCB.Size = new System.Drawing.Size(163, 17);
+            this.updateTimestampCB.Size = new System.Drawing.Size(204, 20);
             this.updateTimestampCB.TabIndex = 41;
             this.updateTimestampCB.Text = "Update Timestamp on Export";
             this.updateTimestampCB.UseVisualStyleBackColor = true;
@@ -777,18 +845,20 @@ namespace osuReplayEditor
             // 
             this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(646, 565);
+            this.label3.Location = new System.Drawing.Point(867, 673);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(74, 13);
+            this.label3.Size = new System.Drawing.Size(90, 16);
             this.label3.TabIndex = 26;
             this.label3.Text = "Other Settings";
             // 
             // analyzeAccBtn
             // 
             this.analyzeAccBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.analyzeAccBtn.Location = new System.Drawing.Point(997, 31);
+            this.analyzeAccBtn.Location = new System.Drawing.Point(1329, 38);
+            this.analyzeAccBtn.Margin = new System.Windows.Forms.Padding(4);
             this.analyzeAccBtn.Name = "analyzeAccBtn";
-            this.analyzeAccBtn.Size = new System.Drawing.Size(75, 23);
+            this.analyzeAccBtn.Size = new System.Drawing.Size(100, 28);
             this.analyzeAccBtn.TabIndex = 44;
             this.analyzeAccBtn.Text = "Analyze Acc";
             this.analyzeAccBtn.UseVisualStyleBackColor = true;
@@ -798,9 +868,10 @@ namespace osuReplayEditor
             // 
             this.label6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label6.AutoSize = true;
-            this.label6.Location = new System.Drawing.Point(995, 91);
+            this.label6.Location = new System.Drawing.Point(1327, 112);
+            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(27, 13);
+            this.label6.Size = new System.Drawing.Size(31, 16);
             this.label6.TabIndex = 47;
             this.label6.Text = "50s:";
             // 
@@ -808,9 +879,10 @@ namespace osuReplayEditor
             // 
             this.label8.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label8.AutoSize = true;
-            this.label8.Location = new System.Drawing.Point(995, 121);
+            this.label8.Location = new System.Drawing.Point(1327, 149);
+            this.label8.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label8.Name = "label8";
-            this.label8.Size = new System.Drawing.Size(28, 13);
+            this.label8.Size = new System.Drawing.Size(32, 16);
             this.label8.TabIndex = 49;
             this.label8.Text = "acc:";
             // 
@@ -818,9 +890,10 @@ namespace osuReplayEditor
             // 
             this.nextMissBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.nextMissBtn.Enabled = false;
-            this.nextMissBtn.Location = new System.Drawing.Point(997, 211);
+            this.nextMissBtn.Location = new System.Drawing.Point(1329, 260);
+            this.nextMissBtn.Margin = new System.Windows.Forms.Padding(4);
             this.nextMissBtn.Name = "nextMissBtn";
-            this.nextMissBtn.Size = new System.Drawing.Size(75, 23);
+            this.nextMissBtn.Size = new System.Drawing.Size(100, 28);
             this.nextMissBtn.TabIndex = 43;
             this.nextMissBtn.Text = "Next Miss";
             this.nextMissBtn.UseVisualStyleBackColor = true;
@@ -830,9 +903,10 @@ namespace osuReplayEditor
             // 
             this.label4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(995, 61);
+            this.label4.Location = new System.Drawing.Point(1327, 75);
+            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(33, 13);
+            this.label4.Size = new System.Drawing.Size(38, 16);
             this.label4.TabIndex = 45;
             this.label4.Text = "300s:";
             // 
@@ -840,9 +914,10 @@ namespace osuReplayEditor
             // 
             this.label5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(995, 76);
+            this.label5.Location = new System.Drawing.Point(1327, 94);
+            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(33, 13);
+            this.label5.Size = new System.Drawing.Size(38, 16);
             this.label5.TabIndex = 46;
             this.label5.Text = "100s:";
             // 
@@ -850,9 +925,10 @@ namespace osuReplayEditor
             // 
             this.label7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label7.AutoSize = true;
-            this.label7.Location = new System.Drawing.Point(995, 106);
+            this.label7.Location = new System.Drawing.Point(1327, 130);
+            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(41, 13);
+            this.label7.Size = new System.Drawing.Size(53, 16);
             this.label7.TabIndex = 48;
             this.label7.Text = "misses:";
             // 
@@ -860,9 +936,10 @@ namespace osuReplayEditor
             // 
             this.label9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(995, 136);
+            this.label9.Location = new System.Drawing.Point(1327, 167);
+            this.label9.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label9.Name = "label9";
-            this.label9.Size = new System.Drawing.Size(53, 13);
+            this.label9.Size = new System.Drawing.Size(66, 16);
             this.label9.TabIndex = 50;
             this.label9.Text = "avg early:";
             // 
@@ -870,9 +947,10 @@ namespace osuReplayEditor
             // 
             this.label10.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label10.AutoSize = true;
-            this.label10.Location = new System.Drawing.Point(995, 151);
+            this.label10.Location = new System.Drawing.Point(1327, 186);
+            this.label10.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label10.Name = "label10";
-            this.label10.Size = new System.Drawing.Size(48, 13);
+            this.label10.Size = new System.Drawing.Size(58, 16);
             this.label10.TabIndex = 51;
             this.label10.Text = "avg late:";
             // 
@@ -880,9 +958,10 @@ namespace osuReplayEditor
             // 
             this.label11.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label11.AutoSize = true;
-            this.label11.Location = new System.Drawing.Point(995, 166);
+            this.label11.Location = new System.Drawing.Point(1327, 204);
+            this.label11.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label11.Name = "label11";
-            this.label11.Size = new System.Drawing.Size(71, 13);
+            this.label11.Size = new System.Drawing.Size(87, 16);
             this.label11.TabIndex = 52;
             this.label11.Text = "unstable rate:";
             // 
@@ -890,9 +969,10 @@ namespace osuReplayEditor
             // 
             this.acc_ur_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_ur_tb.AutoSize = true;
-            this.acc_ur_tb.Location = new System.Drawing.Point(1061, 166);
+            this.acc_ur_tb.Location = new System.Drawing.Point(1415, 204);
+            this.acc_ur_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_ur_tb.Name = "acc_ur_tb";
-            this.acc_ur_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_ur_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_ur_tb.TabIndex = 53;
             this.acc_ur_tb.Text = "?";
             // 
@@ -900,9 +980,10 @@ namespace osuReplayEditor
             // 
             this.acc_avg_late_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_avg_late_tb.AutoSize = true;
-            this.acc_avg_late_tb.Location = new System.Drawing.Point(1061, 151);
+            this.acc_avg_late_tb.Location = new System.Drawing.Point(1415, 186);
+            this.acc_avg_late_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_avg_late_tb.Name = "acc_avg_late_tb";
-            this.acc_avg_late_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_avg_late_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_avg_late_tb.TabIndex = 54;
             this.acc_avg_late_tb.Text = "?";
             // 
@@ -910,9 +991,10 @@ namespace osuReplayEditor
             // 
             this.acc_avg_early_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_avg_early_tb.AutoSize = true;
-            this.acc_avg_early_tb.Location = new System.Drawing.Point(1061, 136);
+            this.acc_avg_early_tb.Location = new System.Drawing.Point(1415, 167);
+            this.acc_avg_early_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_avg_early_tb.Name = "acc_avg_early_tb";
-            this.acc_avg_early_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_avg_early_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_avg_early_tb.TabIndex = 55;
             this.acc_avg_early_tb.Text = "?";
             // 
@@ -920,9 +1002,10 @@ namespace osuReplayEditor
             // 
             this.acc_acc_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_acc_tb.AutoSize = true;
-            this.acc_acc_tb.Location = new System.Drawing.Point(1061, 121);
+            this.acc_acc_tb.Location = new System.Drawing.Point(1415, 149);
+            this.acc_acc_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_acc_tb.Name = "acc_acc_tb";
-            this.acc_acc_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_acc_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_acc_tb.TabIndex = 56;
             this.acc_acc_tb.Text = "?";
             // 
@@ -930,9 +1013,10 @@ namespace osuReplayEditor
             // 
             this.acc_misses_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_misses_tb.AutoSize = true;
-            this.acc_misses_tb.Location = new System.Drawing.Point(1061, 106);
+            this.acc_misses_tb.Location = new System.Drawing.Point(1415, 130);
+            this.acc_misses_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_misses_tb.Name = "acc_misses_tb";
-            this.acc_misses_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_misses_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_misses_tb.TabIndex = 57;
             this.acc_misses_tb.Text = "?";
             // 
@@ -940,9 +1024,10 @@ namespace osuReplayEditor
             // 
             this.acc_50s_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_50s_tb.AutoSize = true;
-            this.acc_50s_tb.Location = new System.Drawing.Point(1061, 91);
+            this.acc_50s_tb.Location = new System.Drawing.Point(1415, 112);
+            this.acc_50s_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_50s_tb.Name = "acc_50s_tb";
-            this.acc_50s_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_50s_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_50s_tb.TabIndex = 58;
             this.acc_50s_tb.Text = "?";
             // 
@@ -950,9 +1035,10 @@ namespace osuReplayEditor
             // 
             this.acc_100s_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_100s_tb.AutoSize = true;
-            this.acc_100s_tb.Location = new System.Drawing.Point(1061, 76);
+            this.acc_100s_tb.Location = new System.Drawing.Point(1415, 94);
+            this.acc_100s_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_100s_tb.Name = "acc_100s_tb";
-            this.acc_100s_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_100s_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_100s_tb.TabIndex = 59;
             this.acc_100s_tb.Text = "?";
             // 
@@ -960,9 +1046,10 @@ namespace osuReplayEditor
             // 
             this.acc_300s_tb.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.acc_300s_tb.AutoSize = true;
-            this.acc_300s_tb.Location = new System.Drawing.Point(1061, 61);
+            this.acc_300s_tb.Location = new System.Drawing.Point(1415, 75);
+            this.acc_300s_tb.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.acc_300s_tb.Name = "acc_300s_tb";
-            this.acc_300s_tb.Size = new System.Drawing.Size(13, 13);
+            this.acc_300s_tb.Size = new System.Drawing.Size(14, 16);
             this.acc_300s_tb.TabIndex = 60;
             this.acc_300s_tb.Text = "?";
             // 
@@ -970,9 +1057,10 @@ namespace osuReplayEditor
             // 
             this.next50btn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.next50btn.Enabled = false;
-            this.next50btn.Location = new System.Drawing.Point(997, 240);
+            this.next50btn.Location = new System.Drawing.Point(1329, 295);
+            this.next50btn.Margin = new System.Windows.Forms.Padding(4);
             this.next50btn.Name = "next50btn";
-            this.next50btn.Size = new System.Drawing.Size(75, 23);
+            this.next50btn.Size = new System.Drawing.Size(100, 28);
             this.next50btn.TabIndex = 61;
             this.next50btn.Text = "Next 50";
             this.next50btn.UseVisualStyleBackColor = true;
@@ -982,9 +1070,10 @@ namespace osuReplayEditor
             // 
             this.next100btn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.next100btn.Enabled = false;
-            this.next100btn.Location = new System.Drawing.Point(997, 269);
+            this.next100btn.Location = new System.Drawing.Point(1329, 331);
+            this.next100btn.Margin = new System.Windows.Forms.Padding(4);
             this.next100btn.Name = "next100btn";
-            this.next100btn.Size = new System.Drawing.Size(75, 23);
+            this.next100btn.Size = new System.Drawing.Size(100, 28);
             this.next100btn.TabIndex = 62;
             this.next100btn.Text = "Next 100";
             this.next100btn.UseVisualStyleBackColor = true;
@@ -994,9 +1083,10 @@ namespace osuReplayEditor
             // 
             this.panel2.Controls.Add(this.toolSelGrabRadioButton);
             this.panel2.Controls.Add(this.toolBrushRadioButton);
-            this.panel2.Location = new System.Drawing.Point(0, 378);
+            this.panel2.Location = new System.Drawing.Point(0, 465);
+            this.panel2.Margin = new System.Windows.Forms.Padding(4);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(94, 55);
+            this.panel2.Size = new System.Drawing.Size(125, 68);
             this.panel2.TabIndex = 64;
             // 
             // toolSelGrabRadioButton
@@ -1006,9 +1096,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Right)));
             this.toolSelGrabRadioButton.AutoSize = true;
             this.toolSelGrabRadioButton.Checked = true;
-            this.toolSelGrabRadioButton.Location = new System.Drawing.Point(10, 13);
+            this.toolSelGrabRadioButton.Location = new System.Drawing.Point(13, 16);
+            this.toolSelGrabRadioButton.Margin = new System.Windows.Forms.Padding(4);
             this.toolSelGrabRadioButton.Name = "toolSelGrabRadioButton";
-            this.toolSelGrabRadioButton.Size = new System.Drawing.Size(90, 17);
+            this.toolSelGrabRadioButton.Size = new System.Drawing.Size(109, 20);
             this.toolSelGrabRadioButton.TabIndex = 5;
             this.toolSelGrabRadioButton.TabStop = true;
             this.toolSelGrabRadioButton.Text = "Select + Grab";
@@ -1021,9 +1112,10 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.toolBrushRadioButton.AutoSize = true;
-            this.toolBrushRadioButton.Location = new System.Drawing.Point(10, 36);
+            this.toolBrushRadioButton.Location = new System.Drawing.Point(13, 44);
+            this.toolBrushRadioButton.Margin = new System.Windows.Forms.Padding(4);
             this.toolBrushRadioButton.Name = "toolBrushRadioButton";
-            this.toolBrushRadioButton.Size = new System.Drawing.Size(52, 17);
+            this.toolBrushRadioButton.Size = new System.Drawing.Size(62, 20);
             this.toolBrushRadioButton.TabIndex = 6;
             this.toolBrushRadioButton.Text = "Brush";
             this.toolBrushRadioButton.UseVisualStyleBackColor = true;
@@ -1032,19 +1124,21 @@ namespace osuReplayEditor
             // label12
             // 
             this.label12.AutoSize = true;
-            this.label12.Location = new System.Drawing.Point(7, 362);
+            this.label12.Location = new System.Drawing.Point(9, 446);
+            this.label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label12.Name = "label12";
-            this.label12.Size = new System.Drawing.Size(28, 13);
+            this.label12.Size = new System.Drawing.Size(35, 16);
             this.label12.TabIndex = 63;
             this.label12.Text = "Tool";
             // 
             // brushRadiusTrackBar
             // 
-            this.brushRadiusTrackBar.Location = new System.Drawing.Point(0, 453);
+            this.brushRadiusTrackBar.Location = new System.Drawing.Point(0, 558);
+            this.brushRadiusTrackBar.Margin = new System.Windows.Forms.Padding(4);
             this.brushRadiusTrackBar.Maximum = 200;
             this.brushRadiusTrackBar.Minimum = 10;
             this.brushRadiusTrackBar.Name = "brushRadiusTrackBar";
-            this.brushRadiusTrackBar.Size = new System.Drawing.Size(92, 45);
+            this.brushRadiusTrackBar.Size = new System.Drawing.Size(123, 56);
             this.brushRadiusTrackBar.TabIndex = 65;
             this.brushRadiusTrackBar.TickStyle = System.Windows.Forms.TickStyle.None;
             this.brushRadiusTrackBar.Value = 60;
@@ -1053,19 +1147,21 @@ namespace osuReplayEditor
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(7, 438);
+            this.label13.Location = new System.Drawing.Point(9, 539);
+            this.label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label13.Name = "label13";
-            this.label13.Size = new System.Drawing.Size(70, 13);
+            this.label13.Size = new System.Drawing.Size(87, 16);
             this.label13.TabIndex = 66;
             this.label13.Text = "Brush Radius";
             // 
             // brushRadiusLabel
             // 
             this.brushRadiusLabel.AutoSize = true;
-            this.brushRadiusLabel.Location = new System.Drawing.Point(10, 477);
+            this.brushRadiusLabel.Location = new System.Drawing.Point(13, 587);
+            this.brushRadiusLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.brushRadiusLabel.Name = "brushRadiusLabel";
             this.brushRadiusLabel.RightToLeft = System.Windows.Forms.RightToLeft.Yes;
-            this.brushRadiusLabel.Size = new System.Drawing.Size(19, 13);
+            this.brushRadiusLabel.Size = new System.Drawing.Size(21, 16);
             this.brushRadiusLabel.TabIndex = 67;
             this.brushRadiusLabel.Text = "60";
             // 
@@ -1073,9 +1169,10 @@ namespace osuReplayEditor
             // 
             this.label14.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label14.AutoSize = true;
-            this.label14.Location = new System.Drawing.Point(995, 302);
+            this.label14.Location = new System.Drawing.Point(1327, 372);
+            this.label14.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label14.Name = "label14";
-            this.label14.Size = new System.Drawing.Size(94, 13);
+            this.label14.Size = new System.Drawing.Size(113, 16);
             this.label14.TabIndex = 68;
             this.label14.Text = "Current Hit Object:";
             // 
@@ -1084,9 +1181,10 @@ namespace osuReplayEditor
             this.currentHitObjectIdLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.currentHitObjectIdLabel.AutoSize = true;
             this.currentHitObjectIdLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.currentHitObjectIdLabel.Location = new System.Drawing.Point(995, 317);
+            this.currentHitObjectIdLabel.Location = new System.Drawing.Point(1327, 390);
+            this.currentHitObjectIdLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.currentHitObjectIdLabel.Name = "currentHitObjectIdLabel";
-            this.currentHitObjectIdLabel.Size = new System.Drawing.Size(18, 20);
+            this.currentHitObjectIdLabel.Size = new System.Drawing.Size(23, 25);
             this.currentHitObjectIdLabel.TabIndex = 68;
             this.currentHitObjectIdLabel.Text = "?";
             // 
@@ -1094,9 +1192,10 @@ namespace osuReplayEditor
             // 
             this.label15.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label15.AutoSize = true;
-            this.label15.Location = new System.Drawing.Point(995, 358);
+            this.label15.Location = new System.Drawing.Point(1327, 441);
+            this.label15.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label15.Name = "label15";
-            this.label15.Size = new System.Drawing.Size(32, 13);
+            this.label15.Size = new System.Drawing.Size(39, 16);
             this.label15.TabIndex = 69;
             this.label15.Text = "Error:";
             // 
@@ -1105,9 +1204,10 @@ namespace osuReplayEditor
             this.hitObjectErrorLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.hitObjectErrorLabel.AutoSize = true;
             this.hitObjectErrorLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.hitObjectErrorLabel.Location = new System.Drawing.Point(995, 373);
+            this.hitObjectErrorLabel.Location = new System.Drawing.Point(1327, 459);
+            this.hitObjectErrorLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.hitObjectErrorLabel.Name = "hitObjectErrorLabel";
-            this.hitObjectErrorLabel.Size = new System.Drawing.Size(18, 20);
+            this.hitObjectErrorLabel.Size = new System.Drawing.Size(23, 25);
             this.hitObjectErrorLabel.TabIndex = 70;
             this.hitObjectErrorLabel.Text = "?";
             // 
@@ -1116,9 +1216,10 @@ namespace osuReplayEditor
             this.hitObjectPointsLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.hitObjectPointsLabel.AutoSize = true;
             this.hitObjectPointsLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.hitObjectPointsLabel.Location = new System.Drawing.Point(995, 413);
+            this.hitObjectPointsLabel.Location = new System.Drawing.Point(1327, 508);
+            this.hitObjectPointsLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.hitObjectPointsLabel.Name = "hitObjectPointsLabel";
-            this.hitObjectPointsLabel.Size = new System.Drawing.Size(18, 20);
+            this.hitObjectPointsLabel.Size = new System.Drawing.Size(23, 25);
             this.hitObjectPointsLabel.TabIndex = 72;
             this.hitObjectPointsLabel.Text = "?";
             // 
@@ -1126,9 +1227,10 @@ namespace osuReplayEditor
             // 
             this.label17.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label17.AutoSize = true;
-            this.label17.Location = new System.Drawing.Point(995, 398);
+            this.label17.Location = new System.Drawing.Point(1327, 490);
+            this.label17.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(39, 13);
+            this.label17.Size = new System.Drawing.Size(47, 16);
             this.label17.TabIndex = 71;
             this.label17.Text = "Points:";
             // 
@@ -1136,9 +1238,10 @@ namespace osuReplayEditor
             // 
             this.nextObjectBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.nextObjectBtn.Enabled = false;
-            this.nextObjectBtn.Location = new System.Drawing.Point(997, 182);
+            this.nextObjectBtn.Location = new System.Drawing.Point(1329, 224);
+            this.nextObjectBtn.Margin = new System.Windows.Forms.Padding(4);
             this.nextObjectBtn.Name = "nextObjectBtn";
-            this.nextObjectBtn.Size = new System.Drawing.Size(75, 23);
+            this.nextObjectBtn.Size = new System.Drawing.Size(100, 28);
             this.nextObjectBtn.TabIndex = 73;
             this.nextObjectBtn.Text = "Next Object";
             this.nextObjectBtn.UseVisualStyleBackColor = true;
@@ -1149,19 +1252,190 @@ namespace osuReplayEditor
             this.currentHitObjectLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.currentHitObjectLabel.AutoSize = true;
             this.currentHitObjectLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.currentHitObjectLabel.Location = new System.Drawing.Point(995, 335);
+            this.currentHitObjectLabel.Location = new System.Drawing.Point(1327, 412);
+            this.currentHitObjectLabel.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.currentHitObjectLabel.Name = "currentHitObjectLabel";
-            this.currentHitObjectLabel.Size = new System.Drawing.Size(18, 20);
+            this.currentHitObjectLabel.Size = new System.Drawing.Size(23, 25);
             this.currentHitObjectLabel.TabIndex = 74;
             this.currentHitObjectLabel.Text = "?";
+            // 
+            // isKeyboardCB
+            // 
+            this.isKeyboardCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.isKeyboardCB.AutoSize = true;
+            this.isKeyboardCB.Checked = true;
+            this.isKeyboardCB.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.isKeyboardCB.Location = new System.Drawing.Point(696, 658);
+            this.isKeyboardCB.Margin = new System.Windows.Forms.Padding(4);
+            this.isKeyboardCB.Name = "isKeyboardCB";
+            this.isKeyboardCB.Size = new System.Drawing.Size(101, 20);
+            this.isKeyboardCB.TabIndex = 80;
+            this.isKeyboardCB.Text = "Is Keyboard";
+            this.isKeyboardCB.UseVisualStyleBackColor = true;
+            // 
+            // drawFramesOnTimelineCB
+            // 
+            this.drawFramesOnTimelineCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.drawFramesOnTimelineCB.AutoSize = true;
+            this.drawFramesOnTimelineCB.Checked = true;
+            this.drawFramesOnTimelineCB.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.drawFramesOnTimelineCB.Location = new System.Drawing.Point(871, 721);
+            this.drawFramesOnTimelineCB.Name = "drawFramesOnTimelineCB";
+            this.drawFramesOnTimelineCB.Size = new System.Drawing.Size(200, 20);
+            this.drawFramesOnTimelineCB.TabIndex = 81;
+            this.drawFramesOnTimelineCB.Text = "Draw All Frames on Timeline";
+            this.drawFramesOnTimelineCB.UseVisualStyleBackColor = true;
+            this.drawFramesOnTimelineCB.CheckedChanged += new System.EventHandler(this.drawFramesOnTimelineCB_CheckedChanged);
+            // 
+            // moveFrameBackBtn
+            // 
+            this.moveFrameBackBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.moveFrameBackBtn.Location = new System.Drawing.Point(1116, 642);
+            this.moveFrameBackBtn.Name = "moveFrameBackBtn";
+            this.moveFrameBackBtn.Size = new System.Drawing.Size(120, 28);
+            this.moveFrameBackBtn.TabIndex = 82;
+            this.moveFrameBackBtn.Text = "Move Back";
+            this.moveFrameBackBtn.UseVisualStyleBackColor = true;
+            this.moveFrameBackBtn.Click += new System.EventHandler(this.moveFrameBackBtn_Click);
+            // 
+            // moveFrameForwardBtn
+            // 
+            this.moveFrameForwardBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.moveFrameForwardBtn.Location = new System.Drawing.Point(1116, 608);
+            this.moveFrameForwardBtn.Name = "moveFrameForwardBtn";
+            this.moveFrameForwardBtn.Size = new System.Drawing.Size(120, 28);
+            this.moveFrameForwardBtn.TabIndex = 83;
+            this.moveFrameForwardBtn.Text = "Move Forward";
+            this.moveFrameForwardBtn.UseVisualStyleBackColor = true;
+            this.moveFrameForwardBtn.Click += new System.EventHandler(this.moveFrameForwardBtn_Click);
+            // 
+            // centerCurrentFrameBtn
+            // 
+            this.centerCurrentFrameBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.centerCurrentFrameBtn.Location = new System.Drawing.Point(1116, 676);
+            this.centerCurrentFrameBtn.Name = "centerCurrentFrameBtn";
+            this.centerCurrentFrameBtn.Size = new System.Drawing.Size(120, 28);
+            this.centerCurrentFrameBtn.TabIndex = 84;
+            this.centerCurrentFrameBtn.Text = "Center";
+            this.centerCurrentFrameBtn.UseVisualStyleBackColor = true;
+            this.centerCurrentFrameBtn.Click += new System.EventHandler(this.centerCurrentFrameBtn_Click);
+            // 
+            // addFrameBtn
+            // 
+            this.addFrameBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.addFrameBtn.Location = new System.Drawing.Point(1242, 608);
+            this.addFrameBtn.Name = "addFrameBtn";
+            this.addFrameBtn.Size = new System.Drawing.Size(120, 28);
+            this.addFrameBtn.TabIndex = 85;
+            this.addFrameBtn.Text = "Add";
+            this.addFrameBtn.UseVisualStyleBackColor = true;
+            this.addFrameBtn.Click += new System.EventHandler(this.addFrameBtn_Click);
+            // 
+            // deleteFrameBtn
+            // 
+            this.deleteFrameBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.deleteFrameBtn.Location = new System.Drawing.Point(1242, 642);
+            this.deleteFrameBtn.Name = "deleteFrameBtn";
+            this.deleteFrameBtn.Size = new System.Drawing.Size(120, 28);
+            this.deleteFrameBtn.TabIndex = 86;
+            this.deleteFrameBtn.Text = "Delete";
+            this.deleteFrameBtn.UseVisualStyleBackColor = true;
+            this.deleteFrameBtn.Click += new System.EventHandler(this.deleteFrameBtn_Click);
+            // 
+            // toKeyboardBtn
+            // 
+            this.toKeyboardBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.toKeyboardBtn.Location = new System.Drawing.Point(1116, 751);
+            this.toKeyboardBtn.Name = "toKeyboardBtn";
+            this.toKeyboardBtn.Size = new System.Drawing.Size(243, 28);
+            this.toKeyboardBtn.TabIndex = 87;
+            this.toKeyboardBtn.Text = "Change All Inputs to Keyboard";
+            this.toKeyboardBtn.UseVisualStyleBackColor = true;
+            this.toKeyboardBtn.Click += new System.EventHandler(this.toKeyboardBtn_Click);
+            // 
+            // openFileDialog2
+            // 
+            this.openFileDialog2.FileName = "beatmap.osu";
+            this.openFileDialog2.Filter = "osu! Beatmap Files (*.osu)|*.osu|All files (*.*)|*.*";
+            this.openFileDialog2.RestoreDirectory = true;
+            this.openFileDialog2.FileOk += new System.ComponentModel.CancelEventHandler(this.openFileDialog2_FileOk);
+            // 
+            // scaleFramesBtn
+            // 
+            this.scaleFramesBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.scaleFramesBtn.Location = new System.Drawing.Point(1242, 676);
+            this.scaleFramesBtn.Name = "scaleFramesBtn";
+            this.scaleFramesBtn.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.scaleFramesBtn.Size = new System.Drawing.Size(120, 28);
+            this.scaleFramesBtn.TabIndex = 88;
+            this.scaleFramesBtn.Text = "Scale";
+            this.scaleFramesBtn.UseVisualStyleBackColor = true;
+            this.scaleFramesBtn.Click += new System.EventHandler(this.scaleFramesBtn_Click);
+            // 
+            // scaleFramesUd
+            // 
+            this.scaleFramesUd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.scaleFramesUd.DecimalPlaces = 3;
+            this.scaleFramesUd.Increment = new decimal(new int[] {
+            1,
+            0,
+            0,
+            65536});
+            this.scaleFramesUd.Location = new System.Drawing.Point(1277, 716);
+            this.scaleFramesUd.Maximum = new decimal(new int[] {
+            2,
+            0,
+            0,
+            0});
+            this.scaleFramesUd.Minimum = new decimal(new int[] {
+            5,
+            0,
+            0,
+            65536});
+            this.scaleFramesUd.Name = "scaleFramesUd";
+            this.scaleFramesUd.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.scaleFramesUd.Size = new System.Drawing.Size(73, 22);
+            this.scaleFramesUd.TabIndex = 91;
+            this.scaleFramesUd.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            // 
+            // drawHitWindowsCB
+            // 
+            this.drawHitWindowsCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.drawHitWindowsCB.AutoSize = true;
+            this.drawHitWindowsCB.Checked = true;
+            this.drawHitWindowsCB.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.drawHitWindowsCB.Location = new System.Drawing.Point(870, 747);
+            this.drawHitWindowsCB.Name = "drawHitWindowsCB";
+            this.drawHitWindowsCB.Size = new System.Drawing.Size(203, 20);
+            this.drawHitWindowsCB.TabIndex = 92;
+            this.drawHitWindowsCB.Text = "Draw Hitwindows on Timeline";
+            this.drawHitWindowsCB.UseVisualStyleBackColor = true;
+            this.drawHitWindowsCB.CheckedChanged += new System.EventHandler(this.drawHitWindowsCB_CheckedChanged);
+            // 
+            // drawSliderendRangeCB
+            // 
+            this.drawSliderendRangeCB.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.drawSliderendRangeCB.AutoSize = true;
+            this.drawSliderendRangeCB.Location = new System.Drawing.Point(870, 773);
+            this.drawSliderendRangeCB.Name = "drawSliderendRangeCB";
+            this.drawSliderendRangeCB.Size = new System.Drawing.Size(184, 20);
+            this.drawSliderendRangeCB.TabIndex = 93;
+            this.drawSliderendRangeCB.Text = "Draw Sliderend Hit Range";
+            this.drawSliderendRangeCB.UseVisualStyleBackColor = true;
+            this.drawSliderendRangeCB.CheckedChanged += new System.EventHandler(this.drawSliderendRangeCB_CheckedChanged);
             // 
             // timelineControl
             // 
             this.timelineControl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.timelineControl.Location = new System.Drawing.Point(100, 438);
+            this.timelineControl.Location = new System.Drawing.Point(133, 539);
+            this.timelineControl.Margin = new System.Windows.Forms.Padding(4);
             this.timelineControl.Name = "timelineControl";
-            this.timelineControl.Size = new System.Drawing.Size(891, 23);
+            this.timelineControl.Size = new System.Drawing.Size(1188, 28);
             this.timelineControl.TabIndex = 16;
             this.timelineControl.Text = "timelineControl";
             this.timelineControl.Value = 0D;
@@ -1174,35 +1448,34 @@ namespace osuReplayEditor
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.canvas.BackColor = System.Drawing.Color.Black;
-            this.canvas.Location = new System.Drawing.Point(100, 33);
+            this.canvas.Location = new System.Drawing.Point(133, 41);
+            this.canvas.Margin = new System.Windows.Forms.Padding(4);
             this.canvas.Name = "canvas";
-            this.canvas.Size = new System.Drawing.Size(891, 400);
+            this.canvas.Size = new System.Drawing.Size(1188, 492);
             this.canvas.TabIndex = 0;
             this.canvas.TabStop = false;
             this.canvas.MouseDown += new System.Windows.Forms.MouseEventHandler(this.canvas_MouseDown);
             this.canvas.MouseMove += new System.Windows.Forms.MouseEventHandler(this.canvas_MouseMove);
             this.canvas.MouseUp += new System.Windows.Forms.MouseEventHandler(this.canvas_MouseUp);
             // 
-            // isKeyboard
-            // 
-			this.isKeyboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.isKeyboard.AutoSize = true;
-            this.isKeyboard.Checked = true;
-            this.isKeyboard.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.isKeyboard.Location = new System.Drawing.Point(522, 534);
-            this.isKeyboard.Name = "isKeyboard";
-            this.isKeyboard.Size = new System.Drawing.Size(82, 17);
-            this.isKeyboard.TabIndex = 80;
-            this.isKeyboard.Text = "Is Keyboard";
-            this.isKeyboard.UseVisualStyleBackColor = true;
-            // 
             // MainForm
             // 
             this.AllowDrop = true;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1184, 661);
-            this.Controls.Add(this.isKeyboard);
+            this.ClientSize = new System.Drawing.Size(1579, 814);
+            this.Controls.Add(this.drawSliderendRangeCB);
+            this.Controls.Add(this.drawHitWindowsCB);
+            this.Controls.Add(this.scaleFramesUd);
+            this.Controls.Add(this.scaleFramesBtn);
+            this.Controls.Add(this.toKeyboardBtn);
+            this.Controls.Add(this.deleteFrameBtn);
+            this.Controls.Add(this.addFrameBtn);
+            this.Controls.Add(this.centerCurrentFrameBtn);
+            this.Controls.Add(this.moveFrameForwardBtn);
+            this.Controls.Add(this.moveFrameBackBtn);
+            this.Controls.Add(this.drawFramesOnTimelineCB);
+            this.Controls.Add(this.isKeyboardCB);
             this.Controls.Add(this.currentHitObjectLabel);
             this.Controls.Add(this.nextObjectBtn);
             this.Controls.Add(this.hitObjectPointsLabel);
@@ -1274,13 +1547,14 @@ namespace osuReplayEditor
             this.Controls.Add(this.menuStrip1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MainMenuStrip = this.menuStrip1;
-            this.Margin = new System.Windows.Forms.Padding(2);
+            this.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.Name = "MainForm";
             this.Text = "osu!ReplayEditor v3";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
             this.Load += new System.EventHandler(this.MainForm_Load);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.MainForm_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.MainForm_DragEnter);
+            this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MainForm_MouseDown);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.volumeBar)).EndInit();
@@ -1292,6 +1566,7 @@ namespace osuReplayEditor
             this.panel2.ResumeLayout(false);
             this.panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.brushRadiusTrackBar)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.scaleFramesUd)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -1310,7 +1585,7 @@ namespace osuReplayEditor
         private System.Windows.Forms.RadioButton playbackRadio075x;
         private System.Windows.Forms.RadioButton playbackRadio100x;
         private System.Windows.Forms.RadioButton playbackRadio150x;
-        private System.Windows.Forms.RadioButton playbackRadio200x;
+        private System.Windows.Forms.RadioButton playbackRadio005x;
         private System.Windows.Forms.RadioButton playbackRadio400x;
         private System.Windows.Forms.Panel playbackSpeedPanel;
         private System.Windows.Forms.Button muteBtn;
@@ -1397,7 +1672,20 @@ namespace osuReplayEditor
         private System.Windows.Forms.ToolStripMenuItem analyzeAccTraceToolStripMenuItem;
         private System.Windows.Forms.Label currentHitObjectLabel;
         private System.Windows.Forms.ToolStripMenuItem configToolStripMenuItem;
-        private System.Windows.Forms.CheckBox isKeyboard;
+        private System.Windows.Forms.CheckBox isKeyboardCB;
+        private System.Windows.Forms.CheckBox drawFramesOnTimelineCB;
+        private System.Windows.Forms.Button moveFrameBackBtn;
+        private System.Windows.Forms.Button moveFrameForwardBtn;
+        private System.Windows.Forms.Button centerCurrentFrameBtn;
+        private System.Windows.Forms.Button addFrameBtn;
+        private System.Windows.Forms.Button deleteFrameBtn;
+        private System.Windows.Forms.Button toKeyboardBtn;
+        private System.Windows.Forms.ToolStripMenuItem changeReplaysBeatmapToolStripMenuItem;
+        private System.Windows.Forms.OpenFileDialog openFileDialog2;
+        private System.Windows.Forms.Button scaleFramesBtn;
+        private System.Windows.Forms.NumericUpDown scaleFramesUd;
+        private System.Windows.Forms.CheckBox drawHitWindowsCB;
+        private System.Windows.Forms.CheckBox drawSliderendRangeCB;
     }
 }
 

--- a/osuReplayEditor/MainForm.cs
+++ b/osuReplayEditor/MainForm.cs
@@ -589,6 +589,9 @@ namespace osuReplayEditor
 
         private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
+            string replayPath = Config.mainConfig.ReplayDirPath;
+            this.openFileDialog1.InitialDirectory = replayPath;
+            this.openFileDialog1.RestoreDirectory = true;
             this.openFileDialog1.ShowDialog();
         }
 
@@ -609,6 +612,9 @@ namespace osuReplayEditor
 
         private void saveFile()
         {
+            string replayPath = Config.mainConfig.ReplayDirPath;
+            this.saveFileDialog1.InitialDirectory = replayPath;
+            this.saveFileDialog1.RestoreDirectory = true;
             this.saveFileDialog1.ShowDialog();
         }
 
@@ -619,7 +625,8 @@ namespace osuReplayEditor
 
         private void exportAsosrToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            this.saveFileDialog1.ShowDialog();
+
+            this.saveFile();
         }
 
         private void saveFileDialog1_FileOk(object sender, System.ComponentModel.CancelEventArgs e)
@@ -957,6 +964,10 @@ namespace osuReplayEditor
             {
                 System.Threading.Thread.Sleep(500);
                 saveFile();
+            }
+            else
+            {
+                MessageBox.Show("Can't find the hash of the map. Try closing osu!", "Warning", MessageBoxButtons.OK, MessageBoxIcon.Warning);
             }
         }
 

--- a/osuReplayEditor/MainForm.cs
+++ b/osuReplayEditor/MainForm.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Windows.Forms;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Linq;
 
 namespace osuReplayEditor
 {
@@ -186,7 +188,8 @@ namespace osuReplayEditor
 
         private void FrameTimer_Tick(object sender, EventArgs e)
         {
-            int dt = (int)(15 * scrubMult);
+            //int dt = (int)(15 * scrubMult);
+            double dt = 15.0 * scrubMult;
             if (scrubRight)
             {
                 API.RelJump(dt);
@@ -200,7 +203,7 @@ namespace osuReplayEditor
 
         private void ScrollBarTimer_Tick(object sender, EventArgs e)
         {
-            int ms = API.GetTime();
+            int ms = (int)API.GetTime();
             this.timelineControl.Value = ms / (double)this.songMax;
             int ms2 = ms % 1000;
             int sec = (ms / 1000) % 60;
@@ -218,6 +221,11 @@ namespace osuReplayEditor
             API.SetVolume(this.volumeBar.Value / 10.0f);
             this.volumeLabel.Text = $"Volume {this.volumeBar.Value * 10}%";
             API.CfgSetVolume(this.volumeBar.Value);
+        }
+
+        private void playbackRadio005x_CheckedChanged(object sender, EventArgs e)
+        {
+            this.ChangePlaybackSpeed();
         }
 
         private void playbackRadio010x_CheckedChanged(object sender, EventArgs e)
@@ -250,10 +258,7 @@ namespace osuReplayEditor
             this.ChangePlaybackSpeed();
         }
 
-        private void playbackRadio200x_CheckedChanged(object sender, EventArgs e)
-        {
-            this.ChangePlaybackSpeed();
-        }
+        
 
         private void playbackRadio400x_CheckedChanged(object sender, EventArgs e)
         {
@@ -262,7 +267,9 @@ namespace osuReplayEditor
 
         private void ChangePlaybackSpeed()
         {
-            if (this.playbackRadio010x.Checked)
+            if (this.playbackRadio005x.Checked)
+                scrubMult = 0.05f;
+            else if(this.playbackRadio010x.Checked)
                 scrubMult = 0.10f;
             else if (this.playbackRadio025x.Checked)
                 scrubMult = 0.25f;
@@ -272,8 +279,6 @@ namespace osuReplayEditor
                 scrubMult = 0.75f;
             else if (this.playbackRadio150x.Checked)
                 scrubMult = 1.5f;
-            else if (this.playbackRadio200x.Checked)
-                scrubMult = 2.0f;
             else if (this.playbackRadio400x.Checked)
                 scrubMult = 4.0f;
             else
@@ -417,17 +422,17 @@ namespace osuReplayEditor
         private void keyPress1Btn_Click(object sender, EventArgs e)
         {
             
-            this.SetFrameKeyPress(this.isKeyboard.Checked ? 5 : 1);
+            this.SetFrameKeyPress(this.isKeyboardCB.Checked ? 5 : 1);
         }
 
         private void keyPress2Btn_Click(object sender, EventArgs e)
         {
-            this.SetFrameKeyPress(this.isKeyboard.Checked ? 10 : 2);
+            this.SetFrameKeyPress(this.isKeyboardCB.Checked ? 10 : 2);
         }
 
         private void keyPress12Btn_Click(object sender, EventArgs e)
         {
-            this.SetFrameKeyPress(this.isKeyboard.Checked ? 15 : 3);
+            this.SetFrameKeyPress(this.isKeyboardCB.Checked ? 15 : 3);
         }
 
         private void SetFrameKeyPress(int mask)
@@ -590,6 +595,16 @@ namespace osuReplayEditor
         private void openFileDialog1_FileOk(object sender, System.ComponentModel.CancelEventArgs e)
         {
             this.LoadReplay(this.openFileDialog1.FileName);
+
+            IntPtr ptr = API.GetMapPath();
+            if (ptr == null) return;
+
+            string path = Marshal.PtrToStringUni(ptr);
+            API.FreeBuffer(ptr);
+
+            this.openFileDialog2.InitialDirectory = Path.GetDirectoryName(path);
+            this.openFileDialog2.FileName = Path.GetFileName(path);
+            this.openFileDialog2.RestoreDirectory = true;
         }
 
         private void saveFile()
@@ -729,7 +744,19 @@ namespace osuReplayEditor
                 currentHitObjectLabel.Text = getKindString(kind);
                 if (isMiss)
                 {
-                    hitObjectErrorLabel.Text = (kind == 3 || kind == 4) ? "Sliderbreak (Miss)" : "Miss";
+                    switch (kind)
+                    {
+                        case 3:
+                            hitObjectErrorLabel.Text = "Sliderbreak (Miss)";
+                            break;
+                        case 4:
+                            hitObjectErrorLabel.Text = "SliderEnd Skip";
+                            break;
+                        default:
+                            hitObjectErrorLabel.Text = "Miss";
+                            break;
+                    }
+                    
                 }
                 else
                 {
@@ -879,6 +906,88 @@ namespace osuReplayEditor
                 analyzeAccuracy(true);
             }
 #endif
+        }
+
+        private void drawFramesOnTimelineCB_CheckedChanged(object sender, EventArgs e)
+        {
+            API.SetDrawFramesOnTimeline(drawFramesOnTimelineCB.Checked);
+        }
+
+        private void moveFrameForwardBtn_Click(object sender, EventArgs e)
+        {
+            API.MoveFrames(1);
+        }
+
+        private void moveFrameBackBtn_Click(object sender, EventArgs e)
+        {
+            API.MoveFrames(-1);
+        }
+
+        private void centerCurrentFrameBtn_Click(object sender, EventArgs e)
+        {
+            API.CenterFrames();
+        }
+
+        private void addFrameBtn_Click(object sender, EventArgs e)
+        {
+            API.AddFrame();
+        }
+
+        private void deleteFrameBtn_Click(object sender, EventArgs e)
+        {
+            API.DeleteFrames();
+        }
+
+        private void toKeyboardBtn_Click(object sender, EventArgs e)
+        {
+            API.DeviceMarkAllFrames(true);
+        }
+
+        private void openFileDialog2_FileOk(object sender, System.ComponentModel.CancelEventArgs e)
+        {
+            string fullPath = this.openFileDialog2.FileName;
+
+            string directory = Path.GetFileName(Path.GetDirectoryName(fullPath));
+            string fileName = Path.GetFileName(fullPath);
+
+            string relativePath = directory + '/' + fileName;
+
+            bool result = API.ChangeHashOfBeatmap(relativePath);
+            if(result)
+            {
+                System.Threading.Thread.Sleep(500);
+                saveFile();
+            }
+        }
+
+        private void changeReplaysBeatmapToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            openFileDialog2.ShowDialog();
+        }
+
+        private void scaleFramesBar_Scroll(object sender, EventArgs e)
+        {
+
+        }
+
+        private void MainForm_MouseDown(object sender, MouseEventArgs e)
+        {
+            this.ActiveControl = null;
+        }
+
+        private void scaleFramesBtn_Click(object sender, EventArgs e)
+        {
+            API.ScaleFrames((float)this.scaleFramesUd.Value);
+        }
+
+        private void drawHitWindowsCB_CheckedChanged(object sender, EventArgs e)
+        {
+            API.SetDrawHitWindows(drawHitWindowsCB.Checked);
+        }
+
+        private void drawSliderendRangeCB_CheckedChanged(object sender, EventArgs e)
+        {
+            API.SetDrawSliderendRange(drawSliderendRangeCB.Checked);
         }
     }
 }

--- a/osuReplayEditor/MainForm.cs
+++ b/osuReplayEditor/MainForm.cs
@@ -962,7 +962,6 @@ namespace osuReplayEditor
             bool result = API.ChangeHashOfBeatmap(relativePath);
             if(result)
             {
-                System.Threading.Thread.Sleep(500);
                 saveFile();
             }
             else

--- a/osuReplayEditor/MainForm.cs
+++ b/osuReplayEditor/MainForm.cs
@@ -599,11 +599,11 @@ namespace osuReplayEditor
         {
             this.LoadReplay(this.openFileDialog1.FileName);
 
-            IntPtr ptr = API.GetMapPath();
-            if (ptr == null) return;
-
-            string path = Marshal.PtrToStringUni(ptr);
-            API.FreeBuffer(ptr);
+            int len = 0;
+            API.GetMapPath(null, ref len);
+            byte[] buf = new byte[len];
+            API.GetMapPath(buf, ref len);
+            string path = System.Text.Encoding.Unicode.GetString(buf, 0, len - 2); // - 2 cuz last symbol is \0
 
             this.openFileDialog2.InitialDirectory = Path.GetDirectoryName(path);
             this.openFileDialog2.FileName = Path.GetFileName(path);

--- a/osuReplayEditor/MainForm.resx
+++ b/osuReplayEditor/MainForm.resx
@@ -126,8 +126,11 @@
   <metadata name="saveFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>272, 17</value>
   </metadata>
+  <metadata name="openFileDialog2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>431, 21</value>
+  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>25</value>
+    <value>57</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/osuReplayEditor/osuReplayEditor.csproj
+++ b/osuReplayEditor/osuReplayEditor.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Maintenance\Updater.cs" />
     <EmbeddedResource Include="ConfigEditor\ConfigEditorForm.resx">
       <DependentUpon>ConfigEditorForm.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="MainForm.resx">
       <DependentUpon>MainForm.cs</DependentUpon>


### PR DESCRIPTION
1) Draw frames on a timeline option
2) Draw hitwindows on a timeline option
3) Draw sliderend range option
4) Sliderends is now drawn
5) Moving frames in time
6) Adding new frames
7) Centering frames
8) Scaling Frames
9) Deleting Frames
10) Changing all inputs to keyboard button
11) (not accurate) missed sliderend detection
12) Changing map file of the replay while keeping inputs
13) Deselect active button by LMB feature
14) Deleted 2.00x playback speed (pretty useless) and added 0.05x playback speed instead
15) Changed time variables that are not bound to frames and objects to double (fix some problems)
16) Added doubletap detection in accuracy analyser